### PR TITLE
Fix placeholder images for anime characters

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,21 @@ import axios from 'axios';
 import { Character } from '../types/types';
 import { UniverseType } from '../data/universes';
 
+function createPlaceholderImage(name: string, color: string): string {
+  const initials = name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='150' height='150'>` +
+    `<rect width='100%' height='100%' fill='${color}'/>` +
+    `<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' ` +
+    `fill='#fff' font-size='60' font-family='Arial, sans-serif'>${initials}</text>` +
+    `</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
 // For demo purposes, this returns mock data
 // In a real app, you'd connect to actual APIs
 export const fetchCharacters = async (
@@ -96,16 +111,16 @@ function formatPokemonName(value: string): string {
 
 function generateNarutoCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
-    { id: 'naruto-1', name: 'Naruto Uzumaki', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-2', name: 'Sasuke Uchiha', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-3', name: 'Sakura Haruno', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-4', name: 'Kakashi Hatake', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-5', name: 'Itachi Uchiha', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-6', name: 'Jiraiya', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-7', name: 'Tsunade', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-8', name: 'Orochimaru', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-9', name: 'Rock Lee', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
-    { id: 'naruto-10', name: 'Gaara', image: 'https://images.pexels.com/photos/1310847/pexels-photo-1310847.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'naruto' },
+    { id: 'naruto-1', name: 'Naruto Uzumaki', image: createPlaceholderImage('Naruto Uzumaki', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-2', name: 'Sasuke Uchiha', image: createPlaceholderImage('Sasuke Uchiha', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-3', name: 'Sakura Haruno', image: createPlaceholderImage('Sakura Haruno', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-4', name: 'Kakashi Hatake', image: createPlaceholderImage('Kakashi Hatake', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-5', name: 'Itachi Uchiha', image: createPlaceholderImage('Itachi Uchiha', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-6', name: 'Jiraiya', image: createPlaceholderImage('Jiraiya', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-7', name: 'Tsunade', image: createPlaceholderImage('Tsunade', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-8', name: 'Orochimaru', image: createPlaceholderImage('Orochimaru', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-9', name: 'Rock Lee', image: createPlaceholderImage('Rock Lee', '#FF7800'), universe: 'naruto' },
+    { id: 'naruto-10', name: 'Gaara', image: createPlaceholderImage('Gaara', '#FF7800'), universe: 'naruto' },
   ];
   
   // In a real app, filter based on selected filters
@@ -114,16 +129,16 @@ function generateNarutoCharacters(filters: string[]): Character[] {
 
 function generateOnePieceCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
-    { id: 'onepiece-1', name: 'Monkey D. Luffy', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-2', name: 'Roronoa Zoro', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-3', name: 'Nami', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-4', name: 'Usopp', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-5', name: 'Sanji', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-6', name: 'Tony Tony Chopper', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-7', name: 'Nico Robin', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-8', name: 'Franky', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-9', name: 'Brook', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
-    { id: 'onepiece-10', name: 'Jinbe', image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'one-piece' },
+    { id: 'onepiece-1', name: 'Monkey D. Luffy', image: createPlaceholderImage('Monkey D. Luffy', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-2', name: 'Roronoa Zoro', image: createPlaceholderImage('Roronoa Zoro', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-3', name: 'Nami', image: createPlaceholderImage('Nami', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-4', name: 'Usopp', image: createPlaceholderImage('Usopp', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-5', name: 'Sanji', image: createPlaceholderImage('Sanji', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-6', name: 'Tony Tony Chopper', image: createPlaceholderImage('Tony Tony Chopper', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-7', name: 'Nico Robin', image: createPlaceholderImage('Nico Robin', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-8', name: 'Franky', image: createPlaceholderImage('Franky', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-9', name: 'Brook', image: createPlaceholderImage('Brook', '#00A3E0'), universe: 'one-piece' },
+    { id: 'onepiece-10', name: 'Jinbe', image: createPlaceholderImage('Jinbe', '#00A3E0'), universe: 'one-piece' },
   ];
   
   return characters;
@@ -131,16 +146,16 @@ function generateOnePieceCharacters(filters: string[]): Character[] {
 
 function generateDragonBallCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
-    { id: 'dragonball-1', name: 'Goku', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-2', name: 'Vegeta', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-3', name: 'Gohan', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-4', name: 'Piccolo', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-5', name: 'Frieza', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-6', name: 'Cell', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-7', name: 'Majin Buu', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-8', name: 'Trunks', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-9', name: 'Krillin', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
-    { id: 'dragonball-10', name: 'Bulma', image: 'https://images.pexels.com/photos/1341279/pexels-photo-1341279.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'dragon-ball' },
+    { id: 'dragonball-1', name: 'Goku', image: createPlaceholderImage('Goku', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-2', name: 'Vegeta', image: createPlaceholderImage('Vegeta', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-3', name: 'Gohan', image: createPlaceholderImage('Gohan', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-4', name: 'Piccolo', image: createPlaceholderImage('Piccolo', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-5', name: 'Frieza', image: createPlaceholderImage('Frieza', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-6', name: 'Cell', image: createPlaceholderImage('Cell', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-7', name: 'Majin Buu', image: createPlaceholderImage('Majin Buu', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-8', name: 'Trunks', image: createPlaceholderImage('Trunks', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-9', name: 'Krillin', image: createPlaceholderImage('Krillin', '#FF9232'), universe: 'dragon-ball' },
+    { id: 'dragonball-10', name: 'Bulma', image: createPlaceholderImage('Bulma', '#FF9232'), universe: 'dragon-ball' },
   ];
   
   return characters;
@@ -148,16 +163,16 @@ function generateDragonBallCharacters(filters: string[]): Character[] {
 
 function generateDemonSlayerCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
-    { id: 'demonslayer-1', name: 'Tanjiro Kamado', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-2', name: 'Nezuko Kamado', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-3', name: 'Zenitsu Agatsuma', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-4', name: 'Inosuke Hashibira', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-5', name: 'Giyu Tomioka', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-6', name: 'Shinobu Kocho', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-7', name: 'Kyojuro Rengoku', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-8', name: 'Tengen Uzui', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-9', name: 'Muzan Kibutsuji', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
-    { id: 'demonslayer-10', name: 'Akaza', image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=150', universe: 'demon-slayer' },
+    { id: 'demonslayer-1', name: 'Tanjiro Kamado', image: createPlaceholderImage('Tanjiro Kamado', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-2', name: 'Nezuko Kamado', image: createPlaceholderImage('Nezuko Kamado', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-3', name: 'Zenitsu Agatsuma', image: createPlaceholderImage('Zenitsu Agatsuma', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-4', name: 'Inosuke Hashibira', image: createPlaceholderImage('Inosuke Hashibira', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-5', name: 'Giyu Tomioka', image: createPlaceholderImage('Giyu Tomioka', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-6', name: 'Shinobu Kocho', image: createPlaceholderImage('Shinobu Kocho', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-7', name: 'Kyojuro Rengoku', image: createPlaceholderImage('Kyojuro Rengoku', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-8', name: 'Tengen Uzui', image: createPlaceholderImage('Tengen Uzui', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-9', name: 'Muzan Kibutsuji', image: createPlaceholderImage('Muzan Kibutsuji', '#28593C'), universe: 'demon-slayer' },
+    { id: 'demonslayer-10', name: 'Akaza', image: createPlaceholderImage('Akaza', '#28593C'), universe: 'demon-slayer' },
   ];
   
   return characters;


### PR DESCRIPTION
## Summary
- add `createPlaceholderImage` helper to `api.ts`
- use unique placeholder images for Naruto, One Piece, Dragon Ball and Demon Slayer characters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6c6ff5848325bb038b958cd14285