### PR TITLE
Fix drag overlay offset

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -8,6 +8,31 @@ interface CharacterCardProps {
   isDragging?: boolean;
 }
 
+/**
+ * Simple presentation component used for both the sortable item and the drag
+ * overlay. This component itself does not register with dnd-kit.
+ */
+export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
+  character,
+  isDragging = false,
+}) => (
+  <div
+    className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+    style={{ opacity: isDragging ? 0.8 : 1 }}
+  >
+    <img
+      src={character.image}
+      alt={character.name}
+      className="w-full h-full object-cover"
+    />
+    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
+      <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
+        {character.name}
+      </span>
+    </div>
+  </div>
+);
+
 const CharacterCard: React.FC<CharacterCardProps> = ({ character, isDragging = false }) => {
   const {
     attributes,

--- a/src/components/TierListGrid.tsx
+++ b/src/components/TierListGrid.tsx
@@ -18,7 +18,7 @@ import {
 } from '@dnd-kit/sortable';
 import { useTheme } from '../context/ThemeContext';
 import Tier from './Tier';
-import CharacterCard from './CharacterCard';
+import CharacterCard, { PlainCharacterCard } from './CharacterCard';
 import CharacterPool from './CharacterPool';
 import { Character } from '../types/types';
 
@@ -213,10 +213,7 @@ const TierListGrid: React.FC<TierListGridProps> = ({ characters }) => {
       
       <DragOverlay>
         {activeId && activeCharacter ? (
-          <CharacterCard 
-            character={activeCharacter}
-            isDragging={true}
-          />
+          <PlainCharacterCard character={activeCharacter} isDragging={true} />
         ) : null}
       </DragOverlay>
     </DndContext>


### PR DESCRIPTION
## Summary
- fix drag overlay offset by separating presentational CharacterCard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f71662f58832599942951af1e3e4e