### PR TITLE
Fix drag overlay offset

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -8,6 +8,31 @@ interface CharacterCardProps {
   isDragging?: boolean;
 }
 
+/**
+ * Simple presentation component used for both the sortable item and the drag
+ * overlay. This component itself does not register with dnd-kit.
+ */
+export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
+  character,
+  isDragging = false,
+}) => (
+  <div
+    className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+    style={{ opacity: isDragging ? 0.8 : 1 }}
+  >
+    <img
+      src={character.image}
+      alt={character.name}
+      className="w-full h-full object-cover"
+    />
+    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
+      <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
+        {character.name}
+      </span>
+    </div>
+  </div>
+);
+
 const CharacterCard: React.FC<CharacterCardProps> = ({ character, isDragging = false }) => {
   const {
     attributes,

--- a/src/components/TierListGrid.tsx
+++ b/src/components/TierListGrid.tsx
@@ -18,7 +18,8 @@ import {
 } from '@dnd-kit/sortable';
 import { useTheme } from '../context/ThemeContext';
 import Tier from './Tier';
-import CharacterCard from './CharacterCard';
+import CharacterCard, { PlainCharacterCard } from './CharacterCard';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
 import CharacterPool from './CharacterPool';
 import { Character } from '../types/types';
 
@@ -35,6 +36,7 @@ const defaultTiers = [
   { id: 'D', label: 'D', color: '#A29BFE' },
   { id: 'F', label: 'F', color: '#636E72' }
 ];
+
 
 const TierListGrid: React.FC<TierListGridProps> = ({ characters }) => {
   const { themeColors } = useTheme();
@@ -211,12 +213,9 @@ const TierListGrid: React.FC<TierListGridProps> = ({ characters }) => {
         />
       </div>
       
-      <DragOverlay>
+      <DragOverlay modifiers={[snapCenterToCursor]}>
         {activeId && activeCharacter ? (
-          <CharacterCard 
-            character={activeCharacter}
-            isDragging={true}
-          />
+          <PlainCharacterCard character={activeCharacter} isDragging={true} />
         ) : null}
       </DragOverlay>
     </DndContext>


### PR DESCRIPTION
## Summary
- snap drag overlay center to cursor with built-in modifier

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f71662f58832599942951af1e3e4e