### PR TITLE
Fix drag offset regression

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -38,7 +38,6 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, isDragging = f
     attributes,
     listeners,
     setNodeRef,
-    setActivatorNodeRef,
     transform,
     transition,
   } = useSortable({ id: character.id });
@@ -51,10 +50,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({ character, isDragging = f
   
   return (
     <div
-      ref={(node) => {
-        setNodeRef(node);
-        setActivatorNodeRef(node);
-      }}
+      ref={setNodeRef}
       style={style}
       {...attributes}
       {...listeners}

--- a/src/components/Tier.tsx
+++ b/src/components/Tier.tsx
@@ -25,7 +25,6 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     attributes,
     listeners,
     setNodeRef,
-    setActivatorNodeRef,
     transform,
     transition,
   } = useSortable({ id });
@@ -50,7 +49,6 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     >
       <div className="flex items-stretch">
         <div
-          ref={setActivatorNodeRef}
           className="w-24 flex items-center justify-center cursor-move"
           style={{ backgroundColor: color }}
           {...attributes}


### PR DESCRIPTION
## Summary
- correct pointer offset by removing unused setActivatorNodeRef

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f76f2b22c8325858e6e19608d5fb8