### PR TITLE
Add Pokémon language selector

### DIFF
--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -10,6 +10,7 @@ const FilterPage: React.FC = () => {
   const navigate = useNavigate();
   const { currentUniverse, setCurrentUniverse, themeColors } = useTheme();
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
+  const [pokemonLanguage, setPokemonLanguage] = useState<'en' | 'fr' | ''>('');
   
   useEffect(() => {
     if (universe && Object.keys(universeConfig).includes(universe as UniverseType)) {
@@ -25,6 +26,29 @@ const FilterPage: React.FC = () => {
 
   const config = universeConfig[currentUniverse];
   const filterOptions = config.filterOptions;
+
+  const languageSelector = currentUniverse === 'pokemon' && (
+    <div className="mb-6">
+      <label htmlFor="pokemon-language" className="block mb-2 font-medium">
+        Select Pokémon Language
+      </label>
+      <select
+        id="pokemon-language"
+        value={pokemonLanguage}
+        onChange={e => {
+          setPokemonLanguage(e.target.value as 'en' | 'fr');
+          setSelectedFilters([]);
+        }}
+        className="border rounded p-2 w-full"
+      >
+        <option value="" disabled>
+          Choose language
+        </option>
+        <option value="en">English</option>
+        <option value="fr">Français</option>
+      </select>
+    </div>
+  );
   
   const handleFilterToggle = (filterId: string) => {
     setSelectedFilters(prev => 
@@ -36,8 +60,14 @@ const FilterPage: React.FC = () => {
   
   const handleContinue = () => {
     if (selectedFilters.length > 0) {
+      if (currentUniverse === 'pokemon' && !pokemonLanguage) {
+        alert('Please select a language first');
+        return;
+      }
       const filterParams = selectedFilters.join(',');
-      navigate(`/tierlist/${currentUniverse}?filters=${filterParams}`);
+      const langParam =
+        currentUniverse === 'pokemon' ? `&lang=${pokemonLanguage}` : '';
+      navigate(`/tierlist/${currentUniverse}?filters=${filterParams}${langParam}`);
     } else {
       // Show error or notification that at least one filter should be selected
       alert('Please select at least one option to continue');
@@ -69,15 +99,23 @@ const FilterPage: React.FC = () => {
             </h2>
           </div>
           
+          {languageSelector}
+
           <p className="mb-6 text-gray-600">
-            Select which {currentUniverse === 'pokemon' ? 'generations' : 
-                        currentUniverse === 'naruto' ? 'series' : 
-                        currentUniverse === 'one-piece' ? 'sagas' : 
-                        currentUniverse === 'dragon-ball' ? 'series' : 
+            Select which {currentUniverse === 'pokemon' ? 'generations' :
+                        currentUniverse === 'naruto' ? 'series' :
+                        currentUniverse === 'one-piece' ? 'sagas' :
+                        currentUniverse === 'dragon-ball' ? 'series' :
                         'seasons'} you want to include in your tier list:
           </p>
           
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-8">
+          <div
+            className={`grid grid-cols-1 md:grid-cols-2 gap-3 mb-8 ${
+              currentUniverse === 'pokemon' && !pokemonLanguage
+                ? 'opacity-50 pointer-events-none'
+                : ''
+            }`}
+          >
             {filterOptions.map((option) => (
               <div 
                 key={option.id}
@@ -121,7 +159,10 @@ const FilterPage: React.FC = () => {
                 backgroundColor: themeColors.primary,
                 boxShadow: `0 4px 14px 0 ${themeColors.primary}40`
               }}
-              disabled={selectedFilters.length === 0}
+              disabled={
+                selectedFilters.length === 0 ||
+                (currentUniverse === 'pokemon' && !pokemonLanguage)
+              }
             >
               <span className="mr-2">Continue</span>
               <ArrowRight size={18} />

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -22,6 +22,7 @@ const TierListPage: React.FC = () => {
 
   // Get selected filters from URL
   const filtersParam = searchParams.get('filters') ?? '';
+  const language = (searchParams.get('lang') ?? 'en') as 'en' | 'fr';
   const filters = useMemo(
     () =>
       filtersParam
@@ -39,7 +40,11 @@ const TierListPage: React.FC = () => {
       const loadCharacters = async () => {
         setLoading(true);
         try {
-          const data = await fetchCharacters(universe as UniverseType, filters);
+          const data = await fetchCharacters(
+            universe as UniverseType,
+            filters,
+            language
+          );
           setCharacters(data);
         } catch (error) {
           console.error('Error fetching characters:', error);
@@ -54,7 +59,7 @@ const TierListPage: React.FC = () => {
     } else {
       navigate('/');
     }
-  }, [universe, filtersParam, setCurrentUniverse, navigate]);
+  }, [universe, filtersParam, language, setCurrentUniverse, navigate]);
   
   const handleAddCustomCharacter = (character: Character) => {
     setCharacters(prev => [...prev, character]);
@@ -64,6 +69,7 @@ const TierListPage: React.FC = () => {
   const tierListData = {
     universe: currentUniverse,
     filters,
+    language,
     characters,
     // In a real app, you'd include the tier assignments here
   };


### PR DESCRIPTION
## Summary
- prompt user to select Pokemon language before choosing a generation
- include language in tier list URL and export data
- fetch Pokemon characters in the requested language

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f850359dc83259033141d13abc123