### PR TITLE
Fix drag for character images

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -25,6 +25,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
       src={character.image}
       alt={character.name}
       className="w-full h-full object-cover"
+      draggable={false}
     />
     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
       <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
@@ -67,6 +68,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
           src={character.image}
           alt={character.name}
           className="w-full h-full object-cover"
+          draggable={false}
         />
         <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
           <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">


### PR DESCRIPTION
## Summary
- prevent browser image drag from interfering with DnD by setting `draggable={false}`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f8f709e288325978b390240112c5a