### PR TITLE
Enable image dragging

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { Move } from 'lucide-react';
 import { Character } from '../types/types';
 import CharacterModal from './CharacterModal';
 
@@ -25,7 +26,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
       src={character.image}
       alt={character.name}
       className="w-full h-full object-cover"
-      draggable={false}
+      draggable={true}
     />
     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
       <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
@@ -59,22 +60,28 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
       <div
         ref={setNodeRef}
         style={style}
-        {...attributes}
-        {...listeners}
-        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+        className="relative w-16 h-16 group rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
         onClick={() => setModalOpen(true)}
       >
         <img
           src={character.image}
           alt={character.name}
           className="w-full h-full object-cover"
-          draggable={false}
+          draggable={true}
         />
-        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
+        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center pointer-events-none">
           <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
             {character.name}
           </span>
         </div>
+        <button
+          {...attributes}
+          {...listeners}
+          className="absolute top-0 right-0 p-0.5 bg-white bg-opacity-70 rounded-bl cursor-grab active:cursor-grabbing"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Move size={12} />
+        </button>
       </div>
       {modalOpen && (
         <CharacterModal character={character} onClose={() => setModalOpen(false)} />


### PR DESCRIPTION
## Summary
- add a drag handle icon to each character card so the image itself can be dragged normally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f908b59c88325a1de23aec4b9a542