### PR TITLE
Enable dragging by card

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -70,11 +70,12 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
           className="w-full h-full object-cover"
           draggable={false}
         />
-        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
+        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center pointer-events-none">
           <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
             {character.name}
           </span>
         </div>
+        
       </div>
       {modalOpen && (
         <CharacterModal character={character} onClose={() => setModalOpen(false)} />


### PR DESCRIPTION
## Summary
- revert drag handle and set draggable to false so the whole card drags

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f908b59c88325a1de23aec4b9a542