### PR TITLE
Fix character drop targets

### DIFF
--- a/src/components/Tier.tsx
+++ b/src/components/Tier.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { useSortable } from '@dnd-kit/sortable';
+import { useDroppable } from '@dnd-kit/core';
+import { useSortable, SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Trash2, Edit2 } from 'lucide-react';
 import { Character } from '../types/types';
@@ -27,7 +28,9 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     setNodeRef,
     transform,
     transition,
-  } = useSortable({ id });
+  } = useSortable({ id: `tier-${id}` });
+
+  const { setNodeRef: setCharactersRef } = useDroppable({ id });
   
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -68,7 +71,10 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
           )}
         </div>
         
-        <div className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50">
+        <div
+          ref={setCharactersRef}
+          className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50"
+        >
           {isEditing ? (
             <input
               type="text"
@@ -78,18 +84,15 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
               autoFocus
             />
           ) : (
-            characters.length > 0 ? (
-              characters.map((character) => (
-                <CharacterCard
-                  key={character.id}
-                  character={character}
-                />
-              ))
-            ) : (
-              <span className="text-gray-400 italic">
-                Drag characters here
-              </span>
-            )
+            <SortableContext items={characters.map(c => c.id)} strategy={rectSortingStrategy}>
+              {characters.length > 0 ? (
+                characters.map((character) => (
+                  <CharacterCard key={character.id} character={character} />
+                ))
+              ) : (
+                <span className="text-gray-400 italic">Drag characters here</span>
+              )}
+            </SortableContext>
           )}
         </div>
         

--- a/src/components/TierListGrid.tsx
+++ b/src/components/TierListGrid.tsx
@@ -219,7 +219,7 @@ const TierListGrid: React.FC<TierListGridProps> = ({ characters, onUnknownChange
       onDragEnd={handleDragEnd}
     >
       <div className="flex flex-col space-y-4 mb-8">
-        <SortableContext items={tiers.map(t => t.id)} strategy={verticalListSortingStrategy}>
+        <SortableContext items={tiers.map(t => `tier-${t.id}`)} strategy={verticalListSortingStrategy}>
           {tiers.map(tier => (
             <Tier
               key={tier.id}


### PR DESCRIPTION
## Summary
- allow dragging characters anywhere within a tier
- adjust tier sortable ids

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f93fccf38832598a4ee5e763f0b15