### PR TITLE
Disable image drag

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Move } from 'lucide-react';
 import { Character } from '../types/types';
 import CharacterModal from './CharacterModal';
 
@@ -26,7 +25,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
       src={character.image}
       alt={character.name}
       className="w-full h-full object-cover"
-      draggable={true}
+      draggable={false}
     />
     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
       <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
@@ -60,28 +59,22 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
       <div
         ref={setNodeRef}
         style={style}
-        className="relative w-16 h-16 group rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+        {...attributes}
+        {...listeners}
+        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
         onClick={() => setModalOpen(true)}
       >
         <img
           src={character.image}
           alt={character.name}
           className="w-full h-full object-cover"
-          draggable={true}
+          draggable={false}
         />
-        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center pointer-events-none">
+        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
           <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
             {character.name}
           </span>
         </div>
-        <button
-          {...attributes}
-          {...listeners}
-          className="absolute top-0 right-0 p-0.5 bg-white bg-opacity-70 rounded-bl cursor-grab active:cursor-grabbing"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Move size={12} />
-        </button>
       </div>
       {modalOpen && (
         <CharacterModal character={character} onClose={() => setModalOpen(false)} />

--- a/src/components/CharacterModal.tsx
+++ b/src/components/CharacterModal.tsx
@@ -28,6 +28,7 @@ const CharacterModal: React.FC<CharacterModalProps> = ({ character, onClose }) =
           src={character.image}
           alt={character.name}
           className="w-full h-auto rounded-md mb-4"
+          draggable={false}
         />
         <h2 className="text-lg font-medium text-center">{character.name}</h2>
       </div>

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -75,7 +75,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
         <div className="mb-4">
           <div className="flex items-start gap-4">
             <div className="w-20 h-20 rounded-md overflow-hidden border border-gray-200">
-              <img src={previewImage} alt="Preview" className="w-full h-full object-cover" />
+              <img src={previewImage} alt="Preview" className="w-full h-full object-cover" draggable={false} />
             </div>
             
             <div className="flex-1">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -63,6 +63,7 @@ const HomePage: React.FC = () => {
                 src={universe.image}
                 alt={universe.name}
                 className="w-full h-56 object-cover transition-transform duration-500 group-hover:scale-110"
+                draggable={false}
               />
               <div className="absolute inset-0 flex flex-col justify-end p-6 z-20">
                 <h3 className="text-2xl font-bold text-white mb-2 drop-shadow-md">


### PR DESCRIPTION
## Summary
- prevent default image drag on CharacterCard, CharacterModal, ImageUploader and HomePage images
- allow dragging the whole CharacterCard block instead of only a drag handle

## Testing
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*
- `npm run build --silent` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f950394488325ba225f70c0affef7