### PR TITLE
Restore early drag code

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Character } from '../types/types';
-import CharacterModal from './CharacterModal';
 
 interface CharacterCardProps {
   character: Character;
@@ -27,7 +26,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
       className="w-full h-full object-cover"
       draggable={false}
     />
-    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center pointer-events-none">
+    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
       <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
         {character.name}
       </span>
@@ -35,18 +34,14 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
   </div>
 );
 
-const CharacterCard: React.FC<CharacterCardProps> = ({
-  character,
-  isDragging = false,
-}) => {
-  const [modalOpen, setModalOpen] = useState(false);
+const CharacterCard: React.FC<CharacterCardProps> = ({ character, isDragging = false }) => {
   const {
     attributes,
     listeners,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
     transition,
-    isDragging: dndDragging,
   } = useSortable({ id: character.id });
   
   const style = {
@@ -56,35 +51,27 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
   };
   
   return (
-    <>
-      <div
-        ref={setNodeRef}
-        style={style}
-        {...attributes}
-        {...listeners}
-        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
-        onClick={() => {
-          if (!dndDragging) {
-            setModalOpen(true);
-          }
-        }}
-      >
-        <img
-          src={character.image}
-          alt={character.name}
-          className="w-full h-full object-cover"
-          draggable={false}
-        />
-        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
-          <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
-            {character.name}
-          </span>
-        </div>
+    <div
+      ref={(node) => {
+        setNodeRef(node);
+        setActivatorNodeRef(node);
+      }}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+    >
+      <img
+        src={character.image}
+        alt={character.name}
+        className="w-full h-full object-cover"
+      />
+      <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
+        <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
+          {character.name}
+        </span>
       </div>
-      {modalOpen && (
-        <CharacterModal character={character} onClose={() => setModalOpen(false)} />
-      )}
-    </>
+    </div>
   );
 };
 

--- a/src/components/Tier.tsx
+++ b/src/components/Tier.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { useDroppable } from '@dnd-kit/core';
-import { useSortable, SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
+import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Trash2, Edit2 } from 'lucide-react';
 import { Character } from '../types/types';
@@ -26,11 +25,10 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     attributes,
     listeners,
     setNodeRef,
+    setActivatorNodeRef,
     transform,
     transition,
-  } = useSortable({ id: `tier-${id}` });
-
-  const { setNodeRef: setCharactersRef } = useDroppable({ id });
+  } = useSortable({ id });
   
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -52,6 +50,7 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     >
       <div className="flex items-stretch">
         <div
+          ref={setActivatorNodeRef}
           className="w-24 flex items-center justify-center cursor-move"
           style={{ backgroundColor: color }}
           {...attributes}
@@ -71,10 +70,7 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
           )}
         </div>
         
-        <div
-          ref={setCharactersRef}
-          className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50"
-        >
+        <div className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50">
           {isEditing ? (
             <input
               type="text"
@@ -84,15 +80,18 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
               autoFocus
             />
           ) : (
-            <SortableContext items={characters.map(c => c.id)} strategy={rectSortingStrategy}>
-              {characters.length > 0 ? (
-                characters.map((character) => (
-                  <CharacterCard key={character.id} character={character} />
-                ))
-              ) : (
-                <span className="text-gray-400 italic">Drag characters here</span>
-              )}
-            </SortableContext>
+            characters.length > 0 ? (
+              characters.map((character) => (
+                <CharacterCard
+                  key={character.id}
+                  character={character}
+                />
+              ))
+            ) : (
+              <span className="text-gray-400 italic">
+                Drag characters here
+              </span>
+            )
           )}
         </div>
         


### PR DESCRIPTION
## Summary
- revert drag-and-drop logic to first working merge
- simplify character cards and tier components to match early implementation

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f983a7c9c83259ac0dc91b6b7fcfd