### PR TITLE
Fix drag overlay position

### DIFF
--- a/src/components/TierListGrid.tsx
+++ b/src/components/TierListGrid.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
 import { 
   DndContext, 
   DragOverlay,
@@ -224,7 +225,7 @@ const TierListGrid: React.FC<TierListGridProps> = ({ characters, onUnknownChange
         />
       </div>
       
-      <DragOverlay>
+      <DragOverlay modifiers={[snapCenterToCursor]}>
         {activeId && activeCharacter ? (
           <PlainCharacterCard character={activeCharacter} isDragging={true} />
         ) : null}


### PR DESCRIPTION
## Summary
- improve DnD experience so characters stay under the cursor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fa3b4a01c83258bf14d4e23af85d7