### PR TITLE
Add Olive et Tom universe

### DIFF
--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -125,6 +125,27 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
             ))}
           </>
         );
+
+      case 'olive-et-tom':
+        return (
+          <>
+            {/* Simple soccer balls */}
+            {Array.from({ length: 20 }).map((_, index) => (
+              <div
+                key={index}
+                className="absolute rounded-full bg-white border-2 border-black"
+                style={{
+                  width: `${Math.random() * 15 + 10}px`,
+                  height: `${Math.random() * 15 + 10}px`,
+                  top: `${Math.random() * 100}%`,
+                  left: `${Math.random() * 100}%`,
+                  opacity: Math.random() * 0.5 + 0.2,
+                  animation: `float ${Math.random() * 12 + 6}s infinite ease-in-out ${Math.random() * 5}s`,
+                }}
+              />
+            ))}
+          </>
+        );
         
       default:
         return null;

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -1,4 +1,10 @@
-export type UniverseType = 'pokemon' | 'naruto' | 'one-piece' | 'dragon-ball' | 'demon-slayer';
+export type UniverseType =
+  | 'pokemon'
+  | 'naruto'
+  | 'one-piece'
+  | 'dragon-ball'
+  | 'demon-slayer'
+  | 'olive-et-tom';
 
 export interface Universe {
   id: UniverseType;
@@ -37,6 +43,12 @@ export const universes: Universe[] = [
     name: 'Demon Slayer',
     description: 'Create tier lists of characters from each season of Demon Slayer',
     image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
+  },
+  {
+    id: 'olive-et-tom',
+    name: 'Olive et Tom',
+    description: 'Rank the best players from the Captain Tsubasa series',
+    image: 'https://images.pexels.com/photos/114296/pexels-photo-114296.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
   },
 ];
 
@@ -164,6 +176,26 @@ export const universeConfig: Record<UniverseType, {
       { id: 'season2', name: 'Season 2 (Entertainment District Arc)' },
       { id: 'season3', name: 'Season 3 (Swordsmith Village Arc)' },
       { id: 'season4', name: 'Season 4 (Hashira Training Arc)' },
+    ],
+  },
+  'olive-et-tom': {
+    colors: {
+      primary: '#1E90FF', // blue
+      secondary: '#FFD700', // gold
+      accent: '#32CD32', // green
+      background: '#F8F8F8',
+      text: '#2B2B2B',
+    },
+    backgroundStyle: {
+      background: 'linear-gradient(to bottom, #1E90FF, #32CD32)',
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [
+      { id: 'original', name: 'Original Series' },
+      { id: 'road-to-2002', name: 'Road to 2002' },
+      { id: '2018', name: '2018' },
     ],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -91,10 +91,11 @@ const FilterPage: React.FC = () => {
           <div className="flex items-center mb-6">
             <Filter className="mr-3" style={{ color: themeColors.primary }} />
             <h2 className="text-2xl font-bold" style={{ color: themeColors.text }}>
-              Customize Your {currentUniverse === 'pokemon' ? 'Pokémon' : 
-                            currentUniverse === 'one-piece' ? 'One Piece' : 
-                            currentUniverse === 'dragon-ball' ? 'Dragon Ball' : 
-                            currentUniverse === 'demon-slayer' ? 'Demon Slayer' : 
+              Customize Your {currentUniverse === 'pokemon' ? 'Pokémon' :
+                            currentUniverse === 'one-piece' ? 'One Piece' :
+                            currentUniverse === 'dragon-ball' ? 'Dragon Ball' :
+                            currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
+                            currentUniverse === 'olive-et-tom' ? 'Olive et Tom' :
                             'Naruto'} Tier List
             </h2>
           </div>
@@ -106,6 +107,7 @@ const FilterPage: React.FC = () => {
                         currentUniverse === 'naruto' ? 'series' :
                         currentUniverse === 'one-piece' ? 'sagas' :
                         currentUniverse === 'dragon-ball' ? 'series' :
+                        currentUniverse === 'olive-et-tom' ? 'series' :
                         'seasons'} you want to include in your tier list:
           </p>
           

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -100,10 +100,11 @@ const TierListPage: React.FC = () => {
         
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white drop-shadow-md mb-2">
-            {currentUniverse === 'pokemon' ? 'Pokémon' : 
-             currentUniverse === 'one-piece' ? 'One Piece' : 
-             currentUniverse === 'dragon-ball' ? 'Dragon Ball' : 
-             currentUniverse === 'demon-slayer' ? 'Demon Slayer' : 
+            {currentUniverse === 'pokemon' ? 'Pokémon' :
+             currentUniverse === 'one-piece' ? 'One Piece' :
+             currentUniverse === 'dragon-ball' ? 'Dragon Ball' :
+             currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
+             currentUniverse === 'olive-et-tom' ? 'Olive et Tom' :
              'Naruto'} Tier List
           </h1>
           <div className="flex flex-wrap gap-2">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -45,6 +45,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'olive-et-tom') {
+    try {
+      return await fetchOliveEtTomCharacters(filters);
+    } catch (error) {
+      console.error('Error fetching Olive et Tom characters:', error);
+      return generateOliveEtTomCharacters(filters);
+    }
+  }
+
   if (universe === 'demon-slayer') {
     try {
       return await fetchDemonSlayerCharacters(filters);
@@ -78,6 +87,9 @@ function getMockCharacters(universe: UniverseType, filters: string[]): Character
       break;
     case 'demon-slayer':
       characters = generateDemonSlayerCharacters(filters);
+      break;
+    case 'olive-et-tom':
+      characters = generateOliveEtTomCharacters(filters);
       break;
   }
   
@@ -265,6 +277,44 @@ async function fetchNarutoCharacters(filters: string[]): Promise<Character[]> {
   return results;
 }
 
+// Fetch Olive et Tom characters using MyAnimeList/Jikan API
+async function fetchOliveEtTomCharacters(filters: string[]): Promise<Character[]> {
+  const seriesIds: Record<string, number> = {
+    original: 1867, // Captain Tsubasa (1983)
+    'road-to-2002': 3289, // Road to 2002
+    '2018': 36934, // Captain Tsubasa (2018)
+  };
+
+  const results: Character[] = [];
+  const seen = new Set<number>();
+
+  await Promise.all(
+    (filters.length ? filters : Object.keys(seriesIds)).map(async (filter) => {
+      const id = seriesIds[filter];
+      if (!id) return;
+      const { data } = await axios.get(`https://api.jikan.moe/v4/anime/${id}/characters`);
+      const characters = Array.isArray(data?.data) ? data.data : data.results || [];
+
+      characters.forEach((item: any) => {
+        const charId = item.character?.mal_id ?? item.mal_id;
+        if (seen.has(charId)) return;
+        seen.add(charId);
+        results.push({
+          id: `olive-${charId}`,
+          name: item.character?.name ?? item.name,
+          image:
+            item.character?.images?.jpg?.image_url ||
+            item.character?.images?.webp?.image_url ||
+            createPlaceholderImage(item.character?.name ?? item.name, '#1E90FF'),
+          universe: 'olive-et-tom',
+        });
+      });
+    })
+  );
+
+  return results;
+}
+
 function generateNarutoCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
     { id: 'naruto-1', name: 'Naruto Uzumaki', image: createPlaceholderImage('Naruto Uzumaki', '#FF7800'), universe: 'naruto' },
@@ -280,6 +330,18 @@ function generateNarutoCharacters(filters: string[]): Character[] {
   ];
   
   // In a real app, filter based on selected filters
+  return characters;
+}
+
+function generateOliveEtTomCharacters(filters: string[]): Character[] {
+  const characters: Character[] = [
+    { id: 'olive-1', name: 'Tsubasa Ozora', image: createPlaceholderImage('Tsubasa Ozora', '#1E90FF'), universe: 'olive-et-tom' },
+    { id: 'olive-2', name: 'Kojiro Hyuga', image: createPlaceholderImage('Kojiro Hyuga', '#1E90FF'), universe: 'olive-et-tom' },
+    { id: 'olive-3', name: 'Genzo Wakabayashi', image: createPlaceholderImage('Genzo Wakabayashi', '#1E90FF'), universe: 'olive-et-tom' },
+    { id: 'olive-4', name: 'Taro Misaki', image: createPlaceholderImage('Taro Misaki', '#1E90FF'), universe: 'olive-et-tom' },
+    { id: 'olive-5', name: 'Hikaru Matsuyama', image: createPlaceholderImage('Hikaru Matsuyama', '#1E90FF'), universe: 'olive-et-tom' },
+  ];
+
   return characters;
 }
 


### PR DESCRIPTION
## Summary
- add new Olive et Tom category
- theme support and soccer styled background
- API functions to fetch or fallback characters
- adjust pages for new universe

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff96af1b08325a0e2ea7b4a2df222