### PR TITLE
Handle Olive et Tom without filters

### DIFF
--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -192,10 +192,7 @@ export const universeConfig: Record<UniverseType, {
       position: 'relative',
       overflow: 'hidden',
     },
-    filterOptions: [
-      { id: 'original', name: 'Original Series' },
-      { id: 'road-to-2002', name: 'Road to 2002' },
-      { id: '2018', name: '2018' },
-    ],
+    // No filter options for Olive et Tom. All characters are shown.
+    filterOptions: [],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -27,6 +27,13 @@ const FilterPage: React.FC = () => {
   const config = universeConfig[currentUniverse];
   const filterOptions = config.filterOptions;
 
+  // If there are no filters available, skip this page
+  useEffect(() => {
+    if (filterOptions.length === 0) {
+      navigate(`/tierlist/${currentUniverse}`);
+    }
+  }, [filterOptions, navigate, currentUniverse]);
+
   const languageSelector = currentUniverse === 'pokemon' && (
     <div className="mb-6">
       <label htmlFor="pokemon-language" className="block mb-2 font-medium">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,7 +15,12 @@ const HomePage: React.FC = () => {
 
   const handleUniverseSelect = (universeId: string) => {
     setCurrentUniverse(universeId as any);
-    navigate(`/filter/${universeId}`);
+    if (universeId === 'olive-et-tom') {
+      // No filters for Olive et Tom, go straight to tier list
+      navigate(`/tierlist/${universeId}`);
+    } else {
+      navigate(`/filter/${universeId}`);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- skip filter selection step for Olive et Tom
- redirect straight to tier list if no filters exist
- remove filter options from Olive et Tom config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c0ffc9908325aaa52a3382534537