### PR TITLE
Handle Olive et Tom without filters

### DIFF
--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -192,10 +192,7 @@ export const universeConfig: Record<UniverseType, {
       position: 'relative',
       overflow: 'hidden',
     },
-    filterOptions: [
-      { id: 'original', name: 'Original Series' },
-      { id: 'road-to-2002', name: 'Road to 2002' },
-      { id: '2018', name: '2018' },
-    ],
+    // No filter options for Olive et Tom. All characters are shown.
+    filterOptions: [],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -27,6 +27,13 @@ const FilterPage: React.FC = () => {
   const config = universeConfig[currentUniverse];
   const filterOptions = config.filterOptions;
 
+  // If there are no filters available, skip this page
+  useEffect(() => {
+    if (filterOptions.length === 0) {
+      navigate(`/tierlist/${currentUniverse}`);
+    }
+  }, [filterOptions, navigate, currentUniverse]);
+
   const languageSelector = currentUniverse === 'pokemon' && (
     <div className="mb-6">
       <label htmlFor="pokemon-language" className="block mb-2 font-medium">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,7 +15,12 @@ const HomePage: React.FC = () => {
 
   const handleUniverseSelect = (universeId: string) => {
     setCurrentUniverse(universeId as any);
-    navigate(`/filter/${universeId}`);
+    if (universeId === 'olive-et-tom') {
+      // No filters for Olive et Tom, go straight to tier list
+      navigate(`/tierlist/${universeId}`);
+    } else {
+      navigate(`/filter/${universeId}`);
+    }
   };
 
   return (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -335,11 +335,41 @@ function generateNarutoCharacters(filters: string[]): Character[] {
 
 function generateOliveEtTomCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
-    { id: 'olive-1', name: 'Tsubasa Ozora', image: createPlaceholderImage('Tsubasa Ozora', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-2', name: 'Kojiro Hyuga', image: createPlaceholderImage('Kojiro Hyuga', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-3', name: 'Genzo Wakabayashi', image: createPlaceholderImage('Genzo Wakabayashi', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-4', name: 'Taro Misaki', image: createPlaceholderImage('Taro Misaki', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-5', name: 'Hikaru Matsuyama', image: createPlaceholderImage('Hikaru Matsuyama', '#1E90FF'), universe: 'olive-et-tom' },
+    {
+      id: 'olive-1',
+      name: 'Tsubasa Ozora',
+      image:
+        'https://static.wikia.nocookie.net/captain-tsubasa/images/2/21/Tsubasa_Ozora.jpg',
+      universe: 'olive-et-tom',
+    },
+    {
+      id: 'olive-2',
+      name: 'Kojiro Hyuga',
+      image:
+        'https://static.wikia.nocookie.net/captain-tsubasa/images/e/e9/Kojiro_Hyuga.jpg',
+      universe: 'olive-et-tom',
+    },
+    {
+      id: 'olive-3',
+      name: 'Genzo Wakabayashi',
+      image:
+        'https://static.wikia.nocookie.net/captain-tsubasa/images/5/5a/Genzo_Wakabayashi.jpg',
+      universe: 'olive-et-tom',
+    },
+    {
+      id: 'olive-4',
+      name: 'Taro Misaki',
+      image:
+        'https://static.wikia.nocookie.net/captain-tsubasa/images/6/60/Taro_Misaki.jpg',
+      universe: 'olive-et-tom',
+    },
+    {
+      id: 'olive-5',
+      name: 'Hikaru Matsuyama',
+      image:
+        'https://static.wikia.nocookie.net/captain-tsubasa/images/9/99/Hikaru_Matsuyama.jpg',
+      universe: 'olive-et-tom',
+    },
   ];
 
   return characters;


### PR DESCRIPTION
## Summary
- skip filter selection step for Olive et Tom
- redirect straight to tier list if no filters exist
- remove filter options from Olive et Tom config
- add real images for Olive et Tom characters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c0ffc9908325aaa52a3382534537