### PR TITLE
Handle Olive et Tom without filters

### DIFF
--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -192,10 +192,7 @@ export const universeConfig: Record<UniverseType, {
       position: 'relative',
       overflow: 'hidden',
     },
-    filterOptions: [
-      { id: 'original', name: 'Original Series' },
-      { id: 'road-to-2002', name: 'Road to 2002' },
-      { id: '2018', name: '2018' },
-    ],
+    // No filter options for Olive et Tom. All characters are shown.
+    filterOptions: [],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -27,6 +27,13 @@ const FilterPage: React.FC = () => {
   const config = universeConfig[currentUniverse];
   const filterOptions = config.filterOptions;
 
+  // If there are no filters available, skip this page
+  useEffect(() => {
+    if (filterOptions.length === 0) {
+      navigate(`/tierlist/${currentUniverse}`);
+    }
+  }, [filterOptions, navigate, currentUniverse]);
+
   const languageSelector = currentUniverse === 'pokemon' && (
     <div className="mb-6">
       <label htmlFor="pokemon-language" className="block mb-2 font-medium">

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -15,7 +15,12 @@ const HomePage: React.FC = () => {
 
   const handleUniverseSelect = (universeId: string) => {
     setCurrentUniverse(universeId as any);
-    navigate(`/filter/${universeId}`);
+    if (universeId === 'olive-et-tom') {
+      // No filters for Olive et Tom, go straight to tier list
+      navigate(`/tierlist/${universeId}`);
+    } else {
+      navigate(`/filter/${universeId}`);
+    }
   };
 
   return (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,6 +17,24 @@ function createPlaceholderImage(name: string, color: string): string {
   return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
 }
 
+// Fallback avatar specifically themed for soccer characters
+function createSoccerPlaceholderImage(name: string): string {
+  const initials = name
+    .split(' ')
+    .map(n => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='150' height='150'>` +
+    `<rect width='100%' height='100%' fill='#1E90FF'/>` +
+    `<circle cx='75' cy='75' r='45' fill='white' stroke='black' stroke-width='4'/>` +
+    `<text x='75' y='75' dominant-baseline='middle' text-anchor='middle' fill='#000' font-size='40' font-family='Arial, sans-serif'>${initials}</text>` +
+    `</svg>`;
+
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
 // For demo purposes, this returns mock data
 // In a real app, you'd connect to actual APIs
 export const fetchCharacters = async (
@@ -335,11 +353,16 @@ function generateNarutoCharacters(filters: string[]): Character[] {
 
 function generateOliveEtTomCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
-    { id: 'olive-1', name: 'Tsubasa Ozora', image: createPlaceholderImage('Tsubasa Ozora', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-2', name: 'Kojiro Hyuga', image: createPlaceholderImage('Kojiro Hyuga', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-3', name: 'Genzo Wakabayashi', image: createPlaceholderImage('Genzo Wakabayashi', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-4', name: 'Taro Misaki', image: createPlaceholderImage('Taro Misaki', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-5', name: 'Hikaru Matsuyama', image: createPlaceholderImage('Hikaru Matsuyama', '#1E90FF'), universe: 'olive-et-tom' },
+    { id: 'olive-1', name: 'Tsubasa Ozora', image: createSoccerPlaceholderImage('Tsubasa Ozora'), universe: 'olive-et-tom' },
+    { id: 'olive-2', name: 'Kojiro Hyuga', image: createSoccerPlaceholderImage('Kojiro Hyuga'), universe: 'olive-et-tom' },
+    { id: 'olive-3', name: 'Genzo Wakabayashi', image: createSoccerPlaceholderImage('Genzo Wakabayashi'), universe: 'olive-et-tom' },
+    { id: 'olive-4', name: 'Taro Misaki', image: createSoccerPlaceholderImage('Taro Misaki'), universe: 'olive-et-tom' },
+    { id: 'olive-5', name: 'Hikaru Matsuyama', image: createSoccerPlaceholderImage('Hikaru Matsuyama'), universe: 'olive-et-tom' },
+    { id: 'olive-6', name: 'Karl-Heinz Schneider', image: createSoccerPlaceholderImage('Karl-Heinz Schneider'), universe: 'olive-et-tom' },
+    { id: 'olive-7', name: 'Ken Wakashimazu', image: createSoccerPlaceholderImage('Ken Wakashimazu'), universe: 'olive-et-tom' },
+    { id: 'olive-8', name: 'Ryo Ishizaki', image: createSoccerPlaceholderImage('Ryo Ishizaki'), universe: 'olive-et-tom' },
+    { id: 'olive-9', name: 'Shingo Aoi', image: createSoccerPlaceholderImage('Shingo Aoi'), universe: 'olive-et-tom' },
+    { id: 'olive-10', name: 'Takeshi Sawada', image: createSoccerPlaceholderImage('Takeshi Sawada'), universe: 'olive-et-tom' },
   ];
 
   return characters;


### PR DESCRIPTION
## Summary
- skip filter selection step for Olive et Tom
- redirect straight to tier list if no filters exist
- remove filter options from Olive et Tom config
- expand Olive et Tom roster with offline soccer avatars

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6840c0ffc9908325aaa52a3382534537