### PR TITLE
Fix DragOverlay style for dnd-kit

### DIFF
--- a/src/components/TierListGrid.tsx
+++ b/src/components/TierListGrid.tsx
@@ -226,7 +226,9 @@ const TierListGrid: React.FC<TierListGridProps> = ({ characters, onUnknownChange
         />
       </div>
       
-      <DragOverlay>
+      <DragOverlay
+        style={{ position: 'fixed', pointerEvents: 'none', top: 0, left: 0, zIndex: 999 }}
+      >
         {activeId && activeCharacter ? (
           <PlainCharacterCard character={activeCharacter} isDragging={true} />
         ) : null}


### PR DESCRIPTION
## Summary
- ensure the DragOverlay container uses fixed positioning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd82f01c8325bf6405a1839653fe