### PR TITLE
Fix Dragon Ball character fetcher

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -287,8 +287,8 @@ async function fetchDragonBallCharacters(filters: string[]): Promise<Character[]
   let page = 1;
   let hasMore = true;
 
-  // The API may paginate results, so fetch up to 10 pages just in case
-  while (hasMore && page <= 10) {
+  // Fetch all pages from the API until no more results are available
+  while (hasMore) {
     const { data } = await axios.get(`${baseUrl}?page=${page}&limit=100`);
     const items = Array.isArray(data) ? data : data.items || data.results || [];
     allResults.push(...items);


### PR DESCRIPTION
## Summary
- fetch all pages from Dragon Ball API so all characters are available

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f3afaf308325a844cd674e12752e