### PR TITLE
Add Dokkan Battle category

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -22,7 +22,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
     style={{ opacity: isDragging ? 0.8 : 1 }}
   >
     <img
-      src={character.image}
+      src={character.thumbnail ?? character.image}
       alt={character.name}
       className="w-full h-full object-cover"
     />
@@ -64,7 +64,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
         onClick={() => setModalOpen(true)}
       >
         <img
-          src={character.image}
+          src={character.thumbnail ?? character.image}
           alt={character.name}
           className="w-full h-full object-cover"
         />

--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -146,6 +146,29 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
             ))}
           </>
         );
+
+      case 'dokkan-battle':
+        return (
+          <>
+            {/* Floating ki orbs */}
+            {Array.from({ length: 25 }).map((_, index) => (
+              <div
+                key={index}
+                className="absolute rounded-full"
+                style={{
+                  width: `${Math.random() * 10 + 6}px`,
+                  height: `${Math.random() * 10 + 6}px`,
+                  top: `${Math.random() * 100}%`,
+                  left: `${Math.random() * 100}%`,
+                  opacity: Math.random() * 0.6 + 0.3,
+                  backgroundColor: index % 2 === 0 ? '#F9A825' : '#E60012',
+                  boxShadow: `0 0 ${Math.random() * 12 + 6}px ${index % 2 === 0 ? '#F9A82577' : '#E6001277'}`,
+                  animation: `float ${Math.random() * 10 + 5}s infinite ease-in-out ${Math.random() * 5}s`,
+                }}
+              />
+            ))}
+          </>
+        );
         
       default:
         return null;

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -4,7 +4,8 @@ export type UniverseType =
   | 'one-piece'
   | 'dragon-ball'
   | 'demon-slayer'
-  | 'olive-et-tom';
+  | 'olive-et-tom'
+  | 'dokkan-battle';
 
 export interface Universe {
   id: UniverseType;
@@ -49,6 +50,12 @@ export const universes: Universe[] = [
     name: 'Olive et Tom',
     description: 'Rank the best players from the Captain Tsubasa series',
     image: 'https://images.pexels.com/photos/114296/pexels-photo-114296.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
+  },
+  {
+    id: 'dokkan-battle',
+    name: 'Dokkan Battle',
+    description: 'Rank characters from the Dokkan Battle mobile game',
+    image: 'https://images.pexels.com/photos/1812869/pexels-photo-1812869.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
   },
 ];
 
@@ -198,5 +205,21 @@ export const universeConfig: Record<UniverseType, {
       { id: 'road-to-2002', name: 'Road to 2002' },
       { id: '2018', name: '2018' },
     ],
+  },
+  'dokkan-battle': {
+    colors: {
+      primary: '#E60012', // red
+      secondary: '#F9A825', // yellow
+      accent: '#0E0E0E', // dark
+      background: '#F8F8F8',
+      text: '#2B2B2B',
+    },
+    backgroundStyle: {
+      background: 'linear-gradient(to bottom, #2E2E2E, #000000)',
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -59,7 +59,9 @@ const FilterPage: React.FC = () => {
   };
   
   const handleContinue = () => {
-    if (selectedFilters.length > 0) {
+    if (filterOptions.length === 0) {
+      navigate(`/tierlist/${currentUniverse}?filters=`);
+    } else if (selectedFilters.length > 0) {
       if (currentUniverse === 'pokemon' && !pokemonLanguage) {
         alert('Please select a language first');
         return;
@@ -96,6 +98,7 @@ const FilterPage: React.FC = () => {
                             currentUniverse === 'dragon-ball' ? 'Dragon Ball' :
                             currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
                             currentUniverse === 'olive-et-tom' ? 'Olive et Tom' :
+                            currentUniverse === 'dokkan-battle' ? 'Dokkan Battle' :
                             'Naruto'} Tier List
             </h2>
           </div>
@@ -108,24 +111,26 @@ const FilterPage: React.FC = () => {
                         currentUniverse === 'one-piece' ? 'sagas' :
                         currentUniverse === 'dragon-ball' ? 'species' :
                         currentUniverse === 'olive-et-tom' ? 'series' :
+                        currentUniverse === 'dokkan-battle' ? 'characters' :
                         'seasons'} you want to include in your tier list:
           </p>
           
-          <div
-            className={`grid grid-cols-1 md:grid-cols-2 gap-3 mb-8 ${
-              currentUniverse === 'pokemon' && !pokemonLanguage
-                ? 'opacity-50 pointer-events-none'
-                : ''
-            }`}
-          >
-            {filterOptions.map((option) => (
-              <div 
-                key={option.id}
-                className={`border rounded-lg p-4 cursor-pointer transition-all ${
-                  selectedFilters.includes(option.id) 
-                    ? 'border-2 shadow-md' 
-                    : 'border border-gray-200 hover:border-gray-300'
-                }`}
+          {filterOptions.length > 0 && (
+            <div
+              className={`grid grid-cols-1 md:grid-cols-2 gap-3 mb-8 ${
+                currentUniverse === 'pokemon' && !pokemonLanguage
+                  ? 'opacity-50 pointer-events-none'
+                  : ''
+              }`}
+            >
+              {filterOptions.map((option) => (
+                <div
+                  key={option.id}
+                  className={`border rounded-lg p-4 cursor-pointer transition-all ${
+                    selectedFilters.includes(option.id)
+                      ? 'border-2 shadow-md'
+                      : 'border border-gray-200 hover:border-gray-300'
+                  }`}
                 style={{
                   borderColor: selectedFilters.includes(option.id) ? themeColors.primary : '',
                   backgroundColor: selectedFilters.includes(option.id) ? `${themeColors.primary}15` : ''
@@ -150,8 +155,9 @@ const FilterPage: React.FC = () => {
                   <span className="font-medium">{option.name}</span>
                 </div>
               </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
           
           <div className="flex justify-end">
             <button
@@ -162,7 +168,7 @@ const FilterPage: React.FC = () => {
                 boxShadow: `0 4px 14px 0 ${themeColors.primary}40`
               }}
               disabled={
-                selectedFilters.length === 0 ||
+                (filterOptions.length > 0 && selectedFilters.length === 0) ||
                 (currentUniverse === 'pokemon' && !pokemonLanguage)
               }
             >

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -134,6 +134,7 @@ function getImageFromId(id: string) {
              currentUniverse === 'dragon-ball' ? 'Dragon Ball' :
              currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
              currentUniverse === 'olive-et-tom' ? 'Olive et Tom' :
+             currentUniverse === 'dokkan-battle' ? 'Dokkan Battle' :
              'Naruto'} Tier List
           </h1>
           <div className="flex flex-wrap gap-2">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -73,6 +73,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'dokkan-battle') {
+    try {
+      return await fetchDokkanCharacters();
+    } catch (error) {
+      console.error('Error fetching Dokkan Battle characters:', error);
+      return [];
+    }
+  }
+
   if (universe === 'demon-slayer') {
     try {
       return await fetchDemonSlayerCharacters(filters);
@@ -109,6 +118,10 @@ function getMockCharacters(universe: UniverseType, filters: string[]): Character
       break;
     case 'olive-et-tom':
       characters = generateOliveEtTomCharacters(filters);
+      break;
+    case 'dokkan-battle':
+      // No mock generator yet
+      characters = [];
       break;
   }
   
@@ -472,6 +485,43 @@ async function fetchOliveEtTomCharacters(filters: string[]): Promise<Character[]
   );
 
   return results;
+}
+
+// Fetch Dokkan Battle characters using dokkan.fyi API
+async function fetchDokkanCharacters(): Promise<Character[]> {
+  try {
+    const { data } = await axios.get('https://dokkan.fyi/api/cards');
+    const cards = Array.isArray(data) ? data : data.items || data.cards || [];
+    return cards.map((card: any) => {
+      const id = card.id ?? card.cardId ?? card._id ?? card.name;
+      const name = card.name || card.title || `Card ${id}`;
+      const thumb =
+        card.thumbnail ||
+        card.thumb ||
+        card.images?.thumb ||
+        card.image ||
+        '';
+      let image =
+        card.fullImage ||
+        card.image ||
+        card.images?.full ||
+        thumb ||
+        '';
+      if (!image) {
+        image = createPlaceholderImage(name, '#E60012');
+      }
+      return {
+        id: `dokkan-${id}`,
+        name,
+        image,
+        thumbnail: thumb || image,
+        universe: 'dokkan-battle',
+      } as Character;
+    });
+  } catch (error) {
+    console.error('Error fetching Dokkan characters:', error);
+    return [];
+  }
 }
 
 function generateNarutoCharacters(filters: string[]): Character[] {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,6 +2,7 @@ export interface Character {
   id: string;
   name: string;
   image: string;
+  thumbnail?: string;
   universe: string;
   // Add more properties as needed
 }


### PR DESCRIPTION
## Summary
- extend Character interface with optional `thumbnail`
- add Dokkan Battle universe and configuration
- support Dokkan Battle in filter and tier list pages
- fetch characters from dokkan.fyi
- allow universes without filter options
- show small images using `thumbnail` if present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841f4864a3c8325b0708edc58e3472d