### PR TITLE
Remove unused universes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TierSaga - Anime Tier List Creator</title>
-    <meta name="description" content="Create beautiful tier lists for your favorite anime universes including Pokémon, Naruto, One Piece, Dragon Ball, and Demon Slayer." />
+    <meta name="description" content="Create beautiful tier lists for your favorite anime universes including Pokémon, Naruto, Dragon Ball, and Demon Slayer." />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -56,28 +56,6 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
           </>
         );
         
-      case 'one-piece':
-        return (
-          <>
-            {/* Ocean waves and treasure map elements */}
-            <div className="absolute inset-0 bg-[url('https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2')] opacity-20 bg-cover bg-center"></div>
-            <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-blue-900 to-transparent"></div>
-            {Array.from({ length: 10 }).map((_, index) => (
-              <div
-                key={index}
-                className="absolute rounded-full border-2 border-yellow-600 opacity-30"
-                style={{
-                  width: `${Math.random() * 100 + 50}px`,
-                  height: `${Math.random() * 100 + 50}px`,
-                  top: `${Math.random() * 100}%`,
-                  left: `${Math.random() * 100}%`,
-                  borderStyle: 'dashed',
-                  transform: `rotate(${Math.random() * 360}deg)`,
-                }}
-              />
-            ))}
-          </>
-        );
         
       case 'dragon-ball':
         return (
@@ -126,50 +104,6 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
           </>
         );
 
-      case 'olive-et-tom':
-        return (
-          <>
-            {/* Simple soccer balls */}
-            {Array.from({ length: 20 }).map((_, index) => (
-              <div
-                key={index}
-                className="absolute rounded-full bg-white border-2 border-black"
-                style={{
-                  width: `${Math.random() * 15 + 10}px`,
-                  height: `${Math.random() * 15 + 10}px`,
-                  top: `${Math.random() * 100}%`,
-                  left: `${Math.random() * 100}%`,
-                  opacity: Math.random() * 0.5 + 0.2,
-                  animation: `float ${Math.random() * 12 + 6}s infinite ease-in-out ${Math.random() * 5}s`,
-                }}
-              />
-            ))}
-          </>
-        );
-
-      case 'dokkan-battle':
-        return (
-          <>
-            {/* Floating ki orbs */}
-            {Array.from({ length: 25 }).map((_, index) => (
-              <div
-                key={index}
-                className="absolute rounded-full"
-                style={{
-                  width: `${Math.random() * 10 + 6}px`,
-                  height: `${Math.random() * 10 + 6}px`,
-                  top: `${Math.random() * 100}%`,
-                  left: `${Math.random() * 100}%`,
-                  opacity: Math.random() * 0.6 + 0.3,
-                  backgroundColor: index % 2 === 0 ? '#F9A825' : '#E60012',
-                  boxShadow: `0 0 ${Math.random() * 12 + 6}px ${index % 2 === 0 ? '#F9A82577' : '#E6001277'}`,
-                  animation: `float ${Math.random() * 10 + 5}s infinite ease-in-out ${Math.random() * 5}s`,
-                }}
-              />
-            ))}
-          </>
-        );
-        
       default:
         return null;
     }

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -1,11 +1,9 @@
 export type UniverseType =
   | 'pokemon'
   | 'naruto'
-  | 'one-piece'
   | 'dragon-ball'
   | 'demon-slayer'
-  | 'olive-et-tom'
-  | 'dokkan-battle';
+  ;
 
 export interface Universe {
   id: UniverseType;
@@ -28,12 +26,6 @@ export const universes: Universe[] = [
     image: 'https://images.pexels.com/photos/1671324/pexels-photo-1671324.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
   },
   {
-    id: 'one-piece',
-    name: 'One Piece',
-    description: 'Create tier lists of characters from different sagas and islands',
-    image: 'https://images.pexels.com/photos/1998439/pexels-photo-1998439.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-  },
-  {
     id: 'dragon-ball',
     name: 'Dragon Ball',
     description: 'Rank fighters from Dragon Ball Z, Super, GT, and more',
@@ -44,18 +36,6 @@ export const universes: Universe[] = [
     name: 'Demon Slayer',
     description: 'Create tier lists of characters from each season of Demon Slayer',
     image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-  },
-  {
-    id: 'olive-et-tom',
-    name: 'Olive et Tom',
-    description: 'Rank the best players from the Captain Tsubasa series',
-    image: 'https://images.pexels.com/photos/114296/pexels-photo-114296.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-  },
-  {
-    id: 'dokkan-battle',
-    name: 'Dokkan Battle',
-    description: 'Rank characters from the Dokkan Battle mobile game',
-    image: 'https://images.pexels.com/photos/1812869/pexels-photo-1812869.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
   },
 ];
 
@@ -116,33 +96,6 @@ export const universeConfig: Record<UniverseType, {
       { id: 'boruto', name: 'Boruto' },
     ],
   },
-  'one-piece': {
-    colors: {
-      primary: '#00A3E0', // One Piece blue
-      secondary: '#FFF200', // One Piece yellow
-      accent: '#E60012', // One Piece red
-      background: '#F8F8F8',
-      text: '#2B2B2B',
-    },
-    backgroundStyle: {
-      background: 'linear-gradient(to bottom, #0077BE, #001F3F)',
-      backgroundSize: 'cover',
-      position: 'relative',
-      overflow: 'hidden',
-    },
-    filterOptions: [
-      { id: 'east-blue', name: 'East Blue Saga' },
-      { id: 'alabasta', name: 'Alabasta Saga' },
-      { id: 'sky-island', name: 'Sky Island Saga' },
-      { id: 'water-7', name: 'Water 7 Saga' },
-      { id: 'thriller-bark', name: 'Thriller Bark Saga' },
-      { id: 'summit-war', name: 'Summit War Saga' },
-      { id: 'fishman-island', name: 'Fishman Island Saga' },
-      { id: 'dressrosa', name: 'Dressrosa Saga' },
-      { id: 'whole-cake', name: 'Whole Cake Island Saga' },
-      { id: 'wano', name: 'Wano Country Saga' },
-    ],
-  },
   'dragon-ball': {
     colors: {
       primary: '#FF9232', // Dragon Ball orange
@@ -186,40 +139,4 @@ export const universeConfig: Record<UniverseType, {
       { id: 'season4', name: 'Season 4 (Hashira Training Arc)' },
     ],
   },
-  'olive-et-tom': {
-    colors: {
-      primary: '#1E90FF', // blue
-      secondary: '#FFD700', // gold
-      accent: '#32CD32', // green
-      background: '#F8F8F8',
-      text: '#2B2B2B',
-    },
-    backgroundStyle: {
-      background: 'linear-gradient(to bottom, #1E90FF, #32CD32)',
-      backgroundSize: 'cover',
-      position: 'relative',
-      overflow: 'hidden',
-    },
-    filterOptions: [
-      { id: 'original', name: 'Original Series' },
-      { id: 'road-to-2002', name: 'Road to 2002' },
-      { id: '2018', name: '2018' },
-    ],
-  },
-  'dokkan-battle': {
-    colors: {
-      primary: '#E60012', // red
-      secondary: '#F9A825', // yellow
-      accent: '#0E0E0E', // dark
-      background: '#F8F8F8',
-      text: '#2B2B2B',
-    },
-    backgroundStyle: {
-      background: 'linear-gradient(to bottom, #2E2E2E, #000000)',
-      backgroundSize: 'cover',
-      position: 'relative',
-      overflow: 'hidden',
-    },
-    filterOptions: [],
-  },
-};
+}; 

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -94,11 +94,8 @@ const FilterPage: React.FC = () => {
             <Filter className="mr-3" style={{ color: themeColors.primary }} />
             <h2 className="text-2xl font-bold" style={{ color: themeColors.text }}>
               Customize Your {currentUniverse === 'pokemon' ? 'Pokémon' :
-                            currentUniverse === 'one-piece' ? 'One Piece' :
                             currentUniverse === 'dragon-ball' ? 'Dragon Ball' :
                             currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
-                            currentUniverse === 'olive-et-tom' ? 'Olive et Tom' :
-                            currentUniverse === 'dokkan-battle' ? 'Dokkan Battle' :
                             'Naruto'} Tier List
             </h2>
           </div>
@@ -108,10 +105,7 @@ const FilterPage: React.FC = () => {
           <p className="mb-6 text-gray-600">
             Select which {currentUniverse === 'pokemon' ? 'generations' :
                         currentUniverse === 'naruto' ? 'series' :
-                        currentUniverse === 'one-piece' ? 'sagas' :
                         currentUniverse === 'dragon-ball' ? 'species' :
-                        currentUniverse === 'olive-et-tom' ? 'series' :
-                        currentUniverse === 'dokkan-battle' ? 'characters' :
                         'seasons'} you want to include in your tier list:
           </p>
           

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -130,11 +130,8 @@ function getImageFromId(id: string) {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white drop-shadow-md mb-2">
             {currentUniverse === 'pokemon' ? 'Pokémon' :
-             currentUniverse === 'one-piece' ? 'One Piece' :
              currentUniverse === 'dragon-ball' ? 'Dragon Ball' :
              currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
-             currentUniverse === 'olive-et-tom' ? 'Olive et Tom' :
-             currentUniverse === 'dokkan-battle' ? 'Dokkan Battle' :
              'Naruto'} Tier List
           </h1>
           <div className="flex flex-wrap gap-2">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -64,27 +64,6 @@ export const fetchCharacters = async (
     }
   }
 
-  if (universe === 'olive-et-tom') {
-    try {
-      return await fetchOliveEtTomCharacters(filters);
-    } catch (error) {
-      console.error('Error fetching Olive et Tom characters:', error);
-      return generateOliveEtTomCharacters(filters);
-    }
-  }
-
-  if (universe === 'dokkan-battle') {
-    try {
-      const chars = await fetchDokkanCharacters();
-      if (chars.length === 0) {
-        return generateDokkanCharacters();
-      }
-      return chars;
-    } catch (error) {
-      console.error('Error fetching Dokkan Battle characters:', error);
-      return generateDokkanCharacters();
-    }
-  }
 
   if (universe === 'demon-slayer') {
     try {
@@ -111,20 +90,11 @@ function getMockCharacters(universe: UniverseType, filters: string[]): Character
     case 'naruto':
       characters = generateNarutoCharacters(filters);
       break;
-    case 'one-piece':
-      characters = generateOnePieceCharacters(filters);
-      break;
     case 'dragon-ball':
       characters = generateDragonBallCharacters(filters);
       break;
     case 'demon-slayer':
       characters = generateDemonSlayerCharacters(filters);
-      break;
-    case 'olive-et-tom':
-      characters = generateOliveEtTomCharacters(filters);
-      break;
-    case 'dokkan-battle':
-      characters = generateDokkanCharacters();
       break;
   }
   
@@ -452,80 +422,6 @@ async function fetchNarutoCharacters(filters: string[]): Promise<Character[]> {
   return results;
 }
 
-// Fetch Olive et Tom characters using MyAnimeList/Jikan API
-async function fetchOliveEtTomCharacters(filters: string[]): Promise<Character[]> {
-  const seriesIds: Record<string, number> = {
-    original: 1867, // Captain Tsubasa (1983)
-    'road-to-2002': 3289, // Road to 2002
-    '2018': 36934, // Captain Tsubasa (2018)
-  };
-
-  const results: Character[] = [];
-  const seen = new Set<number>();
-
-  await Promise.all(
-    (filters.length ? filters : Object.keys(seriesIds)).map(async (filter) => {
-      const id = seriesIds[filter];
-      if (!id) return;
-      const { data } = await axios.get(`https://api.jikan.moe/v4/anime/${id}/characters`);
-      const characters = Array.isArray(data?.data) ? data.data : data.results || [];
-
-      characters.forEach((item: any) => {
-        const charId = item.character?.mal_id ?? item.mal_id;
-        if (seen.has(charId)) return;
-        seen.add(charId);
-        results.push({
-          id: `olive-${charId}`,
-          name: item.character?.name ?? item.name,
-          image:
-            item.character?.images?.jpg?.image_url ||
-            item.character?.images?.webp?.image_url ||
-            createPlaceholderImage(item.character?.name ?? item.name, '#1E90FF'),
-          universe: 'olive-et-tom',
-        });
-      });
-    })
-  );
-
-  return results;
-}
-
-// Fetch Dokkan Battle characters using dokkan.fyi API
-async function fetchDokkanCharacters(): Promise<Character[]> {
-  try {
-    const { data } = await axios.get('https://dokkan.fyi/api/cards');
-    const cards = Array.isArray(data) ? data : data.items || data.cards || [];
-    return cards.map((card: any) => {
-      const id = card.id ?? card.cardId ?? card._id ?? card.name;
-      const name = card.name || card.title || `Card ${id}`;
-      const thumb =
-        card.thumbnail ||
-        card.thumb ||
-        card.images?.thumb ||
-        card.image ||
-        '';
-      let image =
-        card.fullImage ||
-        card.image ||
-        card.images?.full ||
-        thumb ||
-        '';
-      if (!image) {
-        image = createPlaceholderImage(name, '#E60012');
-      }
-      return {
-        id: `dokkan-${id}`,
-        name,
-        image,
-        thumbnail: thumb || image,
-        universe: 'dokkan-battle',
-      } as Character;
-    });
-  } catch (error) {
-    console.error('Error fetching Dokkan characters:', error);
-    return [];
-  }
-}
 
 function generateNarutoCharacters(filters: string[]): Character[] {
   const characters: Character[] = [
@@ -545,113 +441,6 @@ function generateNarutoCharacters(filters: string[]): Character[] {
   return characters;
 }
 
-function generateOliveEtTomCharacters(filters: string[]): Character[] {
-  const characters: Character[] = [
-    { id: 'olive-1', name: 'Tsubasa Ozora', image: createPlaceholderImage('Tsubasa Ozora', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-2', name: 'Kojiro Hyuga', image: createPlaceholderImage('Kojiro Hyuga', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-3', name: 'Genzo Wakabayashi', image: createPlaceholderImage('Genzo Wakabayashi', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-4', name: 'Taro Misaki', image: createPlaceholderImage('Taro Misaki', '#1E90FF'), universe: 'olive-et-tom' },
-    { id: 'olive-5', name: 'Hikaru Matsuyama', image: createPlaceholderImage('Hikaru Matsuyama', '#1E90FF'), universe: 'olive-et-tom' },
-  ];
-
-  return characters;
-}
-
-function generateDokkanCharacters(): Character[] {
-  const names = ['Goku', 'Vegeta', 'Gohan', 'Frieza', 'Cell', 'Majin Buu', 'Trunks', 'Goten', 'Piccolo', 'Broly'];
-  return names.map((name, index) => ({
-    id: `dokkan-${index + 1}`,
-    name,
-    image: createPlaceholderImage(name, '#E60012'),
-    thumbnail: createPlaceholderImage(name, '#E60012'),
-    universe: 'dokkan-battle',
-  }));
-}
-
-function generateOnePieceCharacters(filters: string[]): Character[] {
-  const bySaga: Record<string, Character[]> = {
-    'east-blue': [
-      { id: 'onepiece-eastblue-1', name: 'Monkey D. Luffy', image: createPlaceholderImage('Monkey D. Luffy', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-eastblue-2', name: 'Roronoa Zoro', image: createPlaceholderImage('Roronoa Zoro', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-eastblue-3', name: 'Nami', image: createPlaceholderImage('Nami', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-eastblue-4', name: 'Usopp', image: createPlaceholderImage('Usopp', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-eastblue-5', name: 'Sanji', image: createPlaceholderImage('Sanji', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'alabasta': [
-      { id: 'onepiece-alabasta-1', name: 'Vivi', image: createPlaceholderImage('Vivi', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-alabasta-2', name: 'Crocodile', image: createPlaceholderImage('Crocodile', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-alabasta-3', name: 'Ace', image: createPlaceholderImage('Ace', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-alabasta-4', name: 'Smoker', image: createPlaceholderImage('Smoker', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-alabasta-5', name: 'Tashigi', image: createPlaceholderImage('Tashigi', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'sky-island': [
-      { id: 'onepiece-sky-1', name: 'Enel', image: createPlaceholderImage('Enel', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-sky-2', name: 'Gan Fall', image: createPlaceholderImage('Gan Fall', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-sky-3', name: 'Conis', image: createPlaceholderImage('Conis', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-sky-4', name: 'Pagaya', image: createPlaceholderImage('Pagaya', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-sky-5', name: 'Wyper', image: createPlaceholderImage('Wyper', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'water-7': [
-      { id: 'onepiece-water7-1', name: 'Iceburg', image: createPlaceholderImage('Iceburg', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-water7-2', name: 'Paulie', image: createPlaceholderImage('Paulie', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-water7-3', name: 'Rob Lucci', image: createPlaceholderImage('Rob Lucci', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-water7-4', name: 'Kaku', image: createPlaceholderImage('Kaku', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-water7-5', name: 'Kalifa', image: createPlaceholderImage('Kalifa', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'thriller-bark': [
-      { id: 'onepiece-thriller-1', name: 'Gecko Moria', image: createPlaceholderImage('Gecko Moria', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-thriller-2', name: 'Perona', image: createPlaceholderImage('Perona', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-thriller-3', name: 'Brook', image: createPlaceholderImage('Brook', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-thriller-4', name: 'Oars', image: createPlaceholderImage('Oars', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-thriller-5', name: 'Hogback', image: createPlaceholderImage('Hogback', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'summit-war': [
-      { id: 'onepiece-summit-1', name: 'Whitebeard', image: createPlaceholderImage('Whitebeard', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-summit-2', name: 'Marco', image: createPlaceholderImage('Marco', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-summit-3', name: 'Boa Hancock', image: createPlaceholderImage('Boa Hancock', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-summit-4', name: 'Garp', image: createPlaceholderImage('Garp', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-summit-5', name: 'Sengoku', image: createPlaceholderImage('Sengoku', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'fishman-island': [
-      { id: 'onepiece-fishman-1', name: 'Hody Jones', image: createPlaceholderImage('Hody Jones', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-fishman-2', name: 'Shirahoshi', image: createPlaceholderImage('Shirahoshi', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-fishman-3', name: 'Fisher Tiger', image: createPlaceholderImage('Fisher Tiger', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-fishman-4', name: 'Jinbe', image: createPlaceholderImage('Jinbe', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-fishman-5', name: 'Arlong', image: createPlaceholderImage('Arlong', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'dressrosa': [
-      { id: 'onepiece-dressrosa-1', name: 'Doflamingo', image: createPlaceholderImage('Doflamingo', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-dressrosa-2', name: 'Law', image: createPlaceholderImage('Law', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-dressrosa-3', name: 'Rebecca', image: createPlaceholderImage('Rebecca', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-dressrosa-4', name: 'Sabo', image: createPlaceholderImage('Sabo', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-dressrosa-5', name: 'Kyros', image: createPlaceholderImage('Kyros', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'whole-cake': [
-      { id: 'onepiece-wholecake-1', name: 'Big Mom', image: createPlaceholderImage('Big Mom', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wholecake-2', name: 'Katakuri', image: createPlaceholderImage('Katakuri', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wholecake-3', name: 'Pudding', image: createPlaceholderImage('Pudding', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wholecake-4', name: 'Pedro', image: createPlaceholderImage('Pedro', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wholecake-5', name: 'Carrot', image: createPlaceholderImage('Carrot', '#00A3E0'), universe: 'one-piece' },
-    ],
-    'wano': [
-      { id: 'onepiece-wano-1', name: 'Kaido', image: createPlaceholderImage('Kaido', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wano-2', name: 'Kozuki Oden', image: createPlaceholderImage('Kozuki Oden', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wano-3', name: 'Yamato', image: createPlaceholderImage('Yamato', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wano-4', name: 'Kidd', image: createPlaceholderImage('Kidd', '#00A3E0'), universe: 'one-piece' },
-      { id: 'onepiece-wano-5', name: 'Killer', image: createPlaceholderImage('Killer', '#00A3E0'), universe: 'one-piece' },
-    ],
-  };
-
-  const characters: Character[] = [];
-  filters.forEach((filter) => {
-    const sagaChars = bySaga[filter];
-    if (sagaChars) {
-      characters.push(...sagaChars);
-    }
-  });
-
-  return characters;
-}
 
 function generateDragonBallCharacters(filters: string[]): Character[] {
   const bySpecies: Record<string, Character[]> = {


### PR DESCRIPTION
## Summary
- drop One Piece, Olive et Tom and Dokkan Battle universes
- adjust universe options and background component
- simplify filter and tier list pages
- prune unused API functions
- update site description

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684200f2a1888325a68b9aa91941b2cc