### PR TITLE
Add Dokkan Battle universe

### DIFF
--- a/src/components/CharacterPool.tsx
+++ b/src/components/CharacterPool.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { Character } from '../types/types';
 import CharacterCard from './CharacterCard';
 import { useTheme } from '../context/ThemeContext';
+import { fetchDokkanCharacters } from '../services/api';
 
 interface CharacterPoolProps {
   id: string;
@@ -11,8 +12,22 @@ interface CharacterPoolProps {
 }
 
 const CharacterPool: React.FC<CharacterPoolProps> = ({ id, characters }) => {
-  const { themeColors } = useTheme();
+  const { themeColors, currentUniverse } = useTheme();
   const { setNodeRef } = useDroppable({ id });
+  const [localCharacters, setLocalCharacters] = useState<Character[]>(characters);
+
+  useEffect(() => {
+    const loadCharacters = async () => {
+      if (currentUniverse === 'dokkan') {
+        const dokkanChars = await fetchDokkanCharacters();
+        setLocalCharacters(dokkanChars);
+      } else {
+        setLocalCharacters(characters);
+      }
+    };
+
+    loadCharacters();
+  }, [currentUniverse, characters]);
   
   return (
     <div className="rounded-lg bg-white shadow-md overflow-hidden">
@@ -20,17 +35,17 @@ const CharacterPool: React.FC<CharacterPoolProps> = ({ id, characters }) => {
         className="p-3 font-medium"
         style={{ backgroundColor: themeColors.secondary, color: 'white' }}
       >
-        Characters Pool ({characters.length})
+        Characters Pool ({localCharacters.length})
       </div>
       
       <div
         ref={setNodeRef}
         className="p-4 min-h-40 bg-gray-50"
       >
-        <SortableContext items={characters.map(c => c.id)} strategy={rectSortingStrategy}>
+        <SortableContext items={localCharacters.map(c => c.id)} strategy={rectSortingStrategy}>
           <div className="flex flex-wrap gap-3">
-            {characters.length > 0 ? (
-              characters.map((character) => (
+            {localCharacters.length > 0 ? (
+              localCharacters.map((character) => (
                 <CharacterCard key={character.id} character={character} />
               ))
             ) : (

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -3,7 +3,7 @@ export type UniverseType =
   | 'naruto'
   | 'dragon-ball'
   | 'demon-slayer'
-  ;
+  | 'dokkan';
 
 export interface Universe {
   id: UniverseType;
@@ -36,6 +36,12 @@ export const universes: Universe[] = [
     name: 'Demon Slayer',
     description: 'Create tier lists of characters from each season of Demon Slayer',
     image: 'https://images.pexels.com/photos/6538889/pexels-photo-6538889.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
+  },
+  {
+    id: 'dokkan',
+    name: 'Dokkan Battle',
+    description: 'Rank units from the Dragon Ball Z Dokkan Battle mobile game',
+    image: '/backgrounds/dokkan.jpg',
   },
 ];
 
@@ -139,4 +145,20 @@ export const universeConfig: Record<UniverseType, {
       { id: 'season4', name: 'Season 4 (Hashira Training Arc)' },
     ],
   },
-}; 
+  'dokkan': {
+    colors: {
+      primary: '#0F62AE',
+      secondary: '#FFD700',
+      accent: '#E2231A',
+      background: '#F8F8F8',
+      text: '#2B2B2B',
+    },
+    backgroundStyle: {
+      background: "url('/backgrounds/dokkan.jpg') center/cover no-repeat",
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [],
+  },
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -55,6 +55,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'dokkan') {
+    try {
+      return await fetchDokkanCharacters();
+    } catch (error) {
+      console.error('Error fetching Dokkan characters:', error);
+      return [];
+    }
+  }
+
   if (universe === 'naruto') {
     try {
       return await fetchNarutoCharacters(filters);
@@ -329,6 +338,25 @@ async function fetchDragonBallCharacters(filters: string[]): Promise<Character[]
       };
     });
 }
+
+export const fetchDokkanCharacters = async () => {
+  try {
+    const res = await fetch('https://dokkan.fyi/api/all');
+    if (!res.ok) throw new Error('Erreur chargement Dokkan');
+    const raw = await res.json();
+    return raw.map((char: any) => ({
+      id: `dokkan-${char.id}`,
+      name: char.name,
+      image: char.image,
+      universe: 'dokkan',
+      rarity: char.rarity,
+      type: char.type,
+    }));
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
+};
 
 // Fetch Demon Slayer characters using MyAnimeList/Jikan API
 async function fetchDemonSlayerCharacters(filters: string[]): Promise<Character[]> {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,6 +4,8 @@ export interface Character {
   image: string;
   thumbnail?: string;
   universe: string;
+  rarity?: string;
+  type?: string;
   // Add more properties as needed
 }
 


### PR DESCRIPTION
## Summary
- include Dokkan Battle universe setup
- fetch Dokkan characters from dokkan.fyi API
- handle dokkan characters in CharacterPool
- extend Character type with rarity and type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842059ac9b8832591e2780ed3bbb28b