### PR TITLE
Increase DB character limit

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -273,17 +273,18 @@ async function fetchDragonBallCharacters(filters: string[]): Promise<Character[]
   const allResults: any[] = [];
   let page = 1;
   let hasMore = true;
+  const limit = 1000; // fetch a large number of characters per request
 
   // Fetch all pages from the API until no more results are available
   while (hasMore) {
-    const { data } = await axios.get(`${baseUrl}?page=${page}&limit=100`);
+    const { data } = await axios.get(`${baseUrl}?page=${page}&limit=${limit}`);
     const items = Array.isArray(data) ? data : data.items || data.results || [];
     allResults.push(...items);
 
     const meta = data.meta || {};
     if (meta.next || (meta.totalPages && page < meta.totalPages)) {
       page += 1;
-    } else if (items.length === 100) {
+    } else if (items.length === limit) {
       page += 1;
     } else {
       hasMore = false;


### PR DESCRIPTION
## Summary
- fetch 1000 Dragon Ball characters per API call to show more DBZ fighters

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68420bbe92748325a415e44d9f37e1fc