### PR TITLE
Fix night mode background overlay

### DIFF
--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -93,7 +93,7 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
       {renderBackgroundElements()}
       
       {/* Overlay for better text contrast */}
-      <div className="absolute inset-0 bg-black opacity-50"></div>
+      <div className="absolute inset-0 bg-white/30 dark:bg-black/60"></div>
       
       <style jsx>{`
         @keyframes twinkle {


### PR DESCRIPTION
## Summary
- adjust universe background overlay to respect light and night modes

## Testing
- `npm run lint` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_684c265bf4b48325af274241443a1f33