### PR TITLE
Add League of Legends universe support

### DIFF
--- a/src/assets/lol-home.svg
+++ b/src/assets/lol-home.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 150">
+  <rect width="300" height="150" fill="#0A1428" />
+  <text x="50%" y="50%" fill="#C89B3C" font-size="48" text-anchor="middle" dominant-baseline="central" font-family="Arial, sans-serif">LoL</text>
+</svg>

--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -82,6 +82,25 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
           </>
         );
 
+      case 'league-of-legends':
+        return (
+          <>
+            {Array.from({ length: 40 }).map((_, index) => (
+              <div
+                key={index}
+                className="absolute rounded-full bg-yellow-500 opacity-20"
+                style={{
+                  width: `${Math.random() * 8 + 4}px`,
+                  height: `${Math.random() * 8 + 4}px`,
+                  top: `${Math.random() * 100}%`,
+                  left: `${Math.random() * 100}%`,
+                  animation: `float ${Math.random() * 12 + 8}s infinite ease-in-out ${Math.random() * 6}s`,
+                }}
+              />
+            ))}
+          </>
+        );
+
       default:
         return null;
     }

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -1,7 +1,8 @@
 export type UniverseType =
   | 'pokemon'
   | 'naruto'
-  | 'demon-slayer';
+  | 'demon-slayer'
+  | 'league-of-legends';
 
 export interface Universe {
   id: UniverseType;
@@ -13,6 +14,7 @@ export interface Universe {
 import pokemonHome from '../assets/pokemon-home.webp';
 import narutoHome from '../assets/naruto-home.png';
 import demonSlayerHome from '../assets/demon-slayer-home.png';
+import lolHome from '../assets/lol-home.svg';
 
 export const universes: Universe[] = [
   {
@@ -32,6 +34,12 @@ export const universes: Universe[] = [
     name: 'Demon Slayer',
     description: 'Create tier lists of characters from each season of Demon Slayer',
     image: demonSlayerHome,
+  },
+  {
+    id: 'league-of-legends',
+    name: 'League of Legends',
+    description: 'Rank your favorite champions by class using Data Dragon',
+    image: lolHome,
   },
 ];
 
@@ -111,6 +119,29 @@ export const universeConfig: Record<UniverseType, {
       { id: 'season2', name: 'Season 2 (Entertainment District Arc)' },
       { id: 'season3', name: 'Season 3 (Swordsmith Village Arc)' },
       { id: 'season4', name: 'Season 4 (Hashira Training Arc)' },
+    ],
+  },
+  'league-of-legends': {
+    colors: {
+      primary: '#5383E8', // League blue
+      secondary: '#F0E6D2', // parchment
+      accent: '#C89B3C', // gold
+      background: '#000',
+      text: '#E5E5E5',
+    },
+    backgroundStyle: {
+      background: 'linear-gradient(to bottom, #0A1428, #000000)',
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [
+      { id: 'Assassin', name: 'Assassin' },
+      { id: 'Fighter', name: 'Fighter' },
+      { id: 'Mage', name: 'Mage' },
+      { id: 'Marksman', name: 'Marksman' },
+      { id: 'Support', name: 'Support' },
+      { id: 'Tank', name: 'Tank' },
     ],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -93,18 +93,26 @@ const FilterPage: React.FC = () => {
           <div className="flex items-center mb-6">
             <Filter className="mr-3" style={{ color: themeColors.primary }} />
             <h2 className="text-2xl font-bold" style={{ color: themeColors.text }}>
-              Customize Your {currentUniverse === 'pokemon' ? 'Pokémon' :
-                            currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
-                            'Naruto'} Tier List
+              Customize Your {currentUniverse === 'pokemon'
+                ? 'Pokémon'
+                : currentUniverse === 'demon-slayer'
+                ? 'Demon Slayer'
+                : currentUniverse === 'league-of-legends'
+                ? 'League of Legends'
+                : 'Naruto'} Tier List
             </h2>
           </div>
           
           {languageSelector}
 
           <p className="mb-6 text-gray-600 dark:text-gray-300">
-            Select which {currentUniverse === 'pokemon' ? 'generations' :
-                        currentUniverse === 'naruto' ? 'series' :
-                        'seasons'} you want to include in your tier list:
+            Select which {currentUniverse === 'pokemon'
+              ? 'generations'
+              : currentUniverse === 'naruto'
+              ? 'series'
+              : currentUniverse === 'league-of-legends'
+              ? 'classes'
+              : 'seasons'} you want to include in your tier list:
           </p>
           
           {filterOptions.length > 0 && (

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -129,9 +129,14 @@ function getImageFromId(id: string) {
         
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white drop-shadow-md mb-2">
-            {currentUniverse === 'pokemon' ? 'Pokémon' :
-             currentUniverse === 'demon-slayer' ? 'Demon Slayer' :
-             'Naruto'} Tier List
+            {currentUniverse === 'pokemon'
+              ? 'Pokémon'
+              : currentUniverse === 'demon-slayer'
+              ? 'Demon Slayer'
+              : currentUniverse === 'league-of-legends'
+              ? 'League of Legends'
+              : 'Naruto'}{' '}
+            Tier List
           </h1>
           <div className="flex flex-wrap gap-2">
             {filters.map(filter => (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { Character } from '../types/types';
 import { UniverseType } from '../data/universes';
 
+const LOL_VERSION = '13.24.1';
+
 function createPlaceholderImage(name: string, color: string): string {
   const initials = name
     .split(' ')
@@ -55,6 +57,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'league-of-legends') {
+    try {
+      return await fetchLeagueCharacters(filters);
+    } catch (error) {
+      console.error('Error fetching League of Legends characters:', error);
+      return generateLeagueCharacters(filters);
+    }
+  }
+
   // For demonstration, simulate an API request with a timeout for other universes
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -73,6 +84,9 @@ function getMockCharacters(universe: UniverseType, filters: string[]): Character
       break;
     case 'demon-slayer':
       characters = generateDemonSlayerCharacters(filters);
+      break;
+    case 'league-of-legends':
+      characters = generateLeagueCharacters(filters);
       break;
   }
   
@@ -401,4 +415,40 @@ function generateDemonSlayerCharacters(filters: string[]): Character[] {
   });
 
   return characters;
+}
+
+// Fetch League of Legends champions using Riot's Data Dragon API
+async function fetchLeagueCharacters(filters: string[]): Promise<Character[]> {
+  const url = `https://ddragon.leagueoflegends.com/cdn/${LOL_VERSION}/data/en_US/champion.json`;
+  const { data } = await axios.get(url);
+  const champs: any[] = Object.values(data.data);
+  return champs
+    .filter(ch => filters.length === 0 || filters.some(f => ch.tags.includes(f)))
+    .map(ch => ({
+      id: `lol-${ch.id}`,
+      name: ch.name,
+      image: `https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${ch.id}_0.jpg`,
+      thumbnail: `https://ddragon.leagueoflegends.com/cdn/${LOL_VERSION}/img/champion/${ch.id}.png`,
+      universe: 'league-of-legends',
+    }));
+}
+
+function generateLeagueCharacters(filters: string[]): Character[] {
+  const sample = [
+    { id: 'Aatrox', tags: ['Fighter', 'Tank'] },
+    { id: 'Ahri', tags: ['Mage', 'Assassin'] },
+    { id: 'Garen', tags: ['Fighter', 'Tank'] },
+    { id: 'Lux', tags: ['Mage', 'Support'] },
+    { id: 'Vayne', tags: ['Marksman', 'Assassin'] },
+  ];
+
+  return sample
+    .filter(ch => filters.length === 0 || filters.some(f => ch.tags.includes(f)))
+    .map(ch => ({
+      id: `lol-${ch.id}`,
+      name: ch.id,
+      image: `https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${ch.id}_0.jpg`,
+      thumbnail: `https://ddragon.leagueoflegends.com/cdn/${LOL_VERSION}/img/champion/${ch.id}.png`,
+      universe: 'league-of-legends',
+    }));
 }


### PR DESCRIPTION
## Summary
- include `league-of-legends` in available universes
- create placeholder home image
- configure League of Legends theme and filter options
- render LoL background elements
- fetch champions from Riot's Data Dragon API with fallback data
- update pages to handle new universe in texts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c357d96f8832585ede97535d997e1