### PR TITLE
Enhance LoL image styles

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -24,7 +24,9 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
     <img
       src={character.thumbnail ?? character.image}
       alt={character.name}
-      className="w-full h-full object-cover"
+      className={`w-full h-full object-cover ${
+        character.universe === 'league-of-legends' ? 'scale-[1.15]' : ''
+      }`}
     />
     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
       <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
@@ -66,7 +68,9 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
         <img
           src={character.thumbnail ?? character.image}
           alt={character.name}
-          className="w-full h-full object-cover"
+          className={`w-full h-full object-cover ${
+            character.universe === 'league-of-legends' ? 'scale-[1.15]' : ''
+          }`}
         />
         <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
           <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">

--- a/src/components/CharacterModal.tsx
+++ b/src/components/CharacterModal.tsx
@@ -15,7 +15,9 @@ const CharacterModal: React.FC<CharacterModalProps> = ({ character, onClose }) =
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg p-4 relative max-w-sm w-full dark:bg-gray-800 dark:text-white"
+        className={`bg-white rounded-lg p-4 relative w-full dark:bg-gray-800 dark:text-white ${
+          character.universe === 'league-of-legends' ? 'max-w-3xl' : 'max-w-sm'
+        }`}
         onClick={(e) => e.stopPropagation()}
       >
         <button
@@ -27,7 +29,9 @@ const CharacterModal: React.FC<CharacterModalProps> = ({ character, onClose }) =
         <img
           src={character.image}
           alt={character.name}
-          className="w-full h-auto rounded-md mb-4"
+          className={`w-full h-auto rounded-md mb-4 ${
+            character.universe === 'league-of-legends' ? 'max-h-[700px]' : ''
+          }`}
         />
         <h2 className="text-lg font-medium text-center">{character.name}</h2>
       </div>


### PR DESCRIPTION
## Summary
- tweak LoL thumbnails so the champion icons zoom in slightly
- enlarge LoL splash images inside the modal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c3799e21c8325bd8676a3abbf27c6