### PR TITLE
Add Capitain Tsubasa universe

### DIFF
--- a/src/assets/capitain-tsubasa-home.svg
+++ b/src/assets/capitain-tsubasa-home.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#0064B1" />
+  <text x="50%" y="50%" dy=".35em" font-family="Arial" font-size="72" text-anchor="middle" fill="#ffffff">CT</text>
+</svg>

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -3,7 +3,8 @@ export type UniverseType =
   | 'naruto'
   | 'demon-slayer'
   | 'league-of-legends'
-  | 'onepiece';
+  | 'onepiece'
+  | 'capitain-tsubasa';
 
 export interface Universe {
   id: UniverseType;
@@ -17,6 +18,7 @@ import narutoHome from '../assets/naruto-home.png';
 import demonSlayerHome from '../assets/demon-slayer-home.png';
 import lolHome from '../assets/lol-home.svg';
 import onePieceHome from '../assets/onepiece-home.svg';
+import capitainTsubasaHome from '../assets/capitain-tsubasa-home.svg';
 
 export const universes: Universe[] = [
   {
@@ -48,6 +50,12 @@ export const universes: Universe[] = [
     name: 'One Piece',
     description: 'Create tier lists of characters from One Piece using Jikan',
     image: onePieceHome,
+  },
+  {
+    id: 'capitain-tsubasa',
+    name: 'Capitain Tsubasa',
+    description: 'Tier lists for characters from the original 1983 series',
+    image: capitainTsubasaHome,
   },
 ];
 
@@ -162,6 +170,22 @@ export const universeConfig: Record<UniverseType, {
     },
     backgroundStyle: {
       background: 'linear-gradient(to bottom, #09203f, #537895)',
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [],
+  },
+  'capitain-tsubasa': {
+    colors: {
+      primary: '#0064B1',
+      secondary: '#E60026',
+      accent: '#FFC800',
+      background: '#F0F0F0',
+      text: '#1F2937',
+    },
+    backgroundStyle: {
+      background: 'linear-gradient(to bottom, #0f5b9e, #0064B1)',
       backgroundSize: 'cover',
       position: 'relative',
       overflow: 'hidden',

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -101,6 +101,8 @@ const FilterPage: React.FC = () => {
                 ? 'League of Legends'
                 : currentUniverse === 'onepiece'
                 ? 'One Piece'
+                : currentUniverse === 'capitain-tsubasa'
+                ? 'Capitain Tsubasa'
                 : 'Naruto'} Tier List
             </h2>
           </div>
@@ -115,6 +117,8 @@ const FilterPage: React.FC = () => {
               : currentUniverse === 'league-of-legends'
               ? 'classes'
               : currentUniverse === 'onepiece'
+              ? 'characters'
+              : currentUniverse === 'capitain-tsubasa'
               ? 'characters'
               : 'seasons'} you want to include in your tier list:
           </p>

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -137,6 +137,8 @@ function getImageFromId(id: string) {
               ? 'League of Legends'
               : currentUniverse === 'onepiece'
               ? 'One Piece'
+              : currentUniverse === 'capitain-tsubasa'
+              ? 'Capitain Tsubasa'
               : 'Naruto'}{' '}
             Tier List
           </h1>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -75,6 +75,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'capitain-tsubasa') {
+    try {
+      return await fetchCapitainTsubasaCharacters();
+    } catch (error) {
+      console.error('Error fetching Capitain Tsubasa characters:', error);
+      return generateCapitainTsubasaCharacters();
+    }
+  }
+
   // For demonstration, simulate an API request with a timeout for other universes
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -493,5 +502,39 @@ function generateOnePieceCharacters(): Character[] {
     name,
     image: createPlaceholderImage(name, '#2E51A2'),
     universe: 'onepiece',
+  }));
+}
+
+// Fetch Capitain Tsubasa characters using Jikan API (1983 series)
+async function fetchCapitainTsubasaCharacters(): Promise<Character[]> {
+  const results: Character[] = [];
+  try {
+    const { data } = await axios.get('https://api.jikan.moe/v4/anime/186/characters');
+    const characters = Array.isArray(data?.data) ? data.data : data.results || [];
+    characters.forEach((item: any) => {
+      results.push({
+        id: `capitain-tsubasa-${item.character?.mal_id ?? item.mal_id}`,
+        name: item.character?.name ?? item.name,
+        image:
+          item.character?.images?.jpg?.image_url ||
+          item.character?.images?.webp?.image_url ||
+          createPlaceholderImage(item.character?.name ?? item.name, '#0064B1'),
+        universe: 'capitain-tsubasa',
+      });
+    });
+  } catch (error) {
+    console.error('Error fetching Capitain Tsubasa characters:', error);
+  }
+
+  return results.length > 0 ? results : generateCapitainTsubasaCharacters();
+}
+
+function generateCapitainTsubasaCharacters(): Character[] {
+  const names = ['Tsubasa Oozora', 'Genzo Wakabayashi', 'Kojiro Hyuga', 'Taro Misaki', 'Ryo Ishizaki'];
+  return names.map((name, index) => ({
+    id: `capitain-tsubasa-${index}`,
+    name,
+    image: createPlaceholderImage(name, '#0064B1'),
+    universe: 'capitain-tsubasa',
   }));
 }


### PR DESCRIPTION
## Summary
- add Capitain Tsubasa assets and universe config
- support Capitain Tsubasa in filter and tier list pages
- fetch Capitain Tsubasa characters from Jikan API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c45b3d9ec832587dc2e137617e160