### PR TITLE
Fix Captain Tsubasa API id

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -505,11 +505,11 @@ function generateOnePieceCharacters(): Character[] {
   }));
 }
 
-// Fetch Capitain Tsubasa characters using Jikan API (1983 series)
+// Fetch Capitain Tsubasa characters using Jikan API (2018 series)
 async function fetchCapitainTsubasaCharacters(): Promise<Character[]> {
   const results: Character[] = [];
   try {
-    const { data } = await axios.get('https://api.jikan.moe/v4/anime/186/characters');
+    const { data } = await axios.get('https://api.jikan.moe/v4/anime/36984/characters');
     const characters = Array.isArray(data?.data) ? data.data : data.results || [];
     characters.forEach((item: any) => {
       results.push({


### PR DESCRIPTION
## Summary
- point Captain Tsubasa fetcher to the 2018 series

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ca19b19a48325b24670e6d572951d