### PR TITLE
Restrict night mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,11 @@ import HomePage from './pages/HomePage';
 import FilterPage from './pages/FilterPage';
 import TierListPage from './pages/TierListPage';
 import { ThemeProvider } from './context/ThemeContext';
-import NightModeToggle from './components/NightModeToggle';
 
 function App() {
   return (
     <ThemeProvider>
       <Router>
-        <NightModeToggle />
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/filter/:universe" element={<FilterPage />} />

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, Filter, ArrowRight } from 'lucide-react';
 import { UniverseType, universeConfig } from '../data/universes';
 import { useTheme } from '../context/ThemeContext';
 import UniverseBackground from '../components/UniverseBackground';
+import NightModeToggle from '../components/NightModeToggle';
 
 const FilterPage: React.FC = () => {
   const { universe } = useParams<{ universe: string }>();
@@ -77,8 +78,9 @@ const FilterPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen relative overflow-hidden">
+    <div className="min-h-screen relative overflow-hidden bg-gray-100 dark:bg-gray-900">
       <UniverseBackground universe={currentUniverse} />
+      <NightModeToggle />
       
       <div className="container mx-auto px-4 py-12 relative z-10">
         <button

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,12 +6,15 @@ import { useTheme } from '../context/ThemeContext';
 
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
-  const { setCurrentUniverse } = useTheme();
+  const { setCurrentUniverse, isNightMode, toggleNightMode } = useTheme();
   
-  // Reset universe on home page
+  // Reset universe on home page and disable night mode
   useEffect(() => {
     setCurrentUniverse(null);
-  }, [setCurrentUniverse]);
+    if (isNightMode) {
+      toggleNightMode();
+    }
+  }, [setCurrentUniverse, isNightMode, toggleNightMode]);
 
   const handleUniverseSelect = (universeId: string) => {
     setCurrentUniverse(universeId as any);

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -5,6 +5,7 @@ import { UniverseType } from '../data/universes';
 import { Character } from '../types/types';
 import { useTheme } from '../context/ThemeContext';
 import UniverseBackground from '../components/UniverseBackground';
+import NightModeToggle from '../components/NightModeToggle';
 import TierListGrid from '../components/TierListGrid';
 import ExportPanel from '../components/ExportPanel';
 import ImageUploader from '../components/ImageUploader';
@@ -108,15 +109,16 @@ function getImageFromId(id: string) {
   
   if (!currentUniverse || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-900">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-white"></div>
+      <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-gray-900 dark:border-white"></div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen relative pb-16">
+    <div className="min-h-screen relative pb-16 bg-gray-100 dark:bg-gray-900">
       <UniverseBackground universe={currentUniverse} />
+      <NightModeToggle />
       
       <div className="container mx-auto px-4 py-12 relative z-10">
         <button


### PR DESCRIPTION
## Summary
- remove `NightModeToggle` from `App` so the home page never shows it
- add `NightModeToggle` and dark backgrounds to `FilterPage` and `TierListPage`
- turn off night mode when visiting `HomePage`
- apply dark theme colours to whole page backgrounds

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684caf750f5c83259be8bf2ecfc0aeb7