### PR TITLE
Fix dark mode border

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -18,7 +18,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
   isDragging = false,
 }) => (
   <div
-    className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+    className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-700"
     style={{ opacity: isDragging ? 0.8 : 1 }}
   >
     <img
@@ -63,7 +63,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
         style={style}
         {...attributes}
         {...listeners}
-        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow"
+        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-700"
         onClick={() => setModalOpen(true)}
       >
         <img


### PR DESCRIPTION
## Summary
- add a darker border color when rendering character cards in dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cb093987083259599b6188ecad73b