### PR TITLE
Improve dark mode persistence and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mankind Tier List</title>
-    <meta name="description" content="Create beautiful tier lists for your favorite anime universes including Pokémon, Naruto, and Demon Slayer." />
+      <meta charset="UTF-8" />
+      <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Mankind Tier List</title>
+      <meta name="description" content="Create beautiful tier lists for your favorite anime universes including Pokémon, Naruto, and Demon Slayer." />
+      <script>
+        try {
+          if (localStorage.getItem('isNightMode') === 'true') {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (e) {}
+      </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -18,7 +18,7 @@ export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
   isDragging = false,
 }) => (
   <div
-    className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-700"
+  className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-500"
     style={{ opacity: isDragging ? 0.8 : 1 }}
   >
     <img
@@ -63,7 +63,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
         style={style}
         {...attributes}
         {...listeners}
-        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-700"
+        className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-500"
         onClick={() => setModalOpen(true)}
       >
         <img


### PR DESCRIPTION
## Summary
- keep night mode active on reload using script in `index.html`
- make character borders more visible in dark theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cb23bb9348325a1782a2b17ab2a32