### PR TITLE
Fix dark mode resetting on HomePage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,15 +6,12 @@ import { useTheme } from '../context/ThemeContext';
 
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
-  const { setCurrentUniverse, isNightMode, toggleNightMode } = useTheme();
+  const { setCurrentUniverse } = useTheme();
   
-  // Reset universe on home page and disable night mode
+  // Reset universe on home page
   useEffect(() => {
     setCurrentUniverse(null);
-    if (isNightMode) {
-      toggleNightMode();
-    }
-  }, [setCurrentUniverse, isNightMode, toggleNightMode]);
+  }, [setCurrentUniverse]);
 
   const handleUniverseSelect = (universeId: string) => {
     setCurrentUniverse(universeId as any);


### PR DESCRIPTION
## Summary
- update HomePage so night mode is not disabled when returning home

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cb4bff9f08325bb5149016614d600