### PR TITLE
Allow dropping characters into tiers

### DIFF
--- a/src/components/Tier.tsx
+++ b/src/components/Tier.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { useSortable } from '@dnd-kit/sortable';
+import { useSortable, SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
+import { useDroppable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import { Trash2, Edit2 } from 'lucide-react';
 import { Character } from '../types/types';
@@ -28,6 +29,7 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     transform,
     transition,
   } = useSortable({ id });
+  const { setNodeRef: setDroppableRef } = useDroppable({ id });
   
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -68,7 +70,10 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
           )}
         </div>
         
-        <div className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50 dark:bg-gray-700">
+        <div
+          ref={setDroppableRef}
+          className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50 dark:bg-gray-700"
+        >
           {isEditing ? (
             <input
               type="text"
@@ -78,18 +83,17 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
               autoFocus
             />
           ) : (
-            characters.length > 0 ? (
-              characters.map((character) => (
-                <CharacterCard
-                  key={character.id}
-                  character={character}
-                />
-              ))
-            ) : (
-              <span className="text-gray-400 italic dark:text-gray-500">
-                Drag characters here
-              </span>
-            )
+            <SortableContext items={characters.map((c) => c.id)} strategy={rectSortingStrategy}>
+              {characters.length > 0 ? (
+                characters.map((character) => (
+                  <CharacterCard key={character.id} character={character} />
+                ))
+              ) : (
+                <span className="text-gray-400 italic dark:text-gray-500">
+                  Drag characters here
+                </span>
+              )}
+            </SortableContext>
           )}
         </div>
         


### PR DESCRIPTION
## Summary
- register tiers as droppable containers
- wrap tier characters with `SortableContext`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cb5dc63688325a8decca1bfbf5c8f