### PR TITLE
Add Harry Potter universe

### DIFF
--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -101,6 +101,25 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
           </>
         );
 
+      case 'harry-potter':
+        return (
+          <>
+            {Array.from({ length: 50 }).map((_, index) => (
+              <div
+                key={index}
+                className="absolute rounded-full bg-yellow-300 opacity-20"
+                style={{
+                  width: `${Math.random() * 6 + 3}px`,
+                  height: `${Math.random() * 6 + 3}px`,
+                  top: `${Math.random() * 100}%`,
+                  left: `${Math.random() * 100}%`,
+                  animation: `float ${Math.random() * 15 + 10}s infinite ease-in-out ${Math.random() * 5}s`,
+                }}
+              />
+            ))}
+          </>
+        );
+
       default:
         return null;
     }

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -3,6 +3,7 @@ export type UniverseType =
   | 'naruto'
   | 'demon-slayer'
   | 'league-of-legends'
+  | 'harry-potter'
   | 'onepiece';
 
 export interface Universe {
@@ -42,6 +43,12 @@ export const universes: Universe[] = [
     name: 'League of Legends',
     description: 'Rank your favorite champions by class using Data Dragon',
     image: lolHome,
+  },
+  {
+    id: 'harry-potter',
+    name: 'Harry Potter',
+    description: 'Create tier lists of wizards and witches from the Wizarding World',
+    image: 'https://images.unsplash.com/photo-1529655683826-aba9b3e77383?auto=format&fit=crop&w=800&q=60',
   },
   {
     id: 'onepiece',
@@ -151,6 +158,22 @@ export const universeConfig: Record<UniverseType, {
       { id: 'Support', name: 'Support' },
       { id: 'Tank', name: 'Tank' },
     ],
+  },
+  'harry-potter': {
+    colors: {
+      primary: '#740001',
+      secondary: '#D3A625',
+      accent: '#222F5B',
+      background: '#F5F5F5',
+      text: '#1F2937',
+    },
+    backgroundStyle: {
+      background: 'linear-gradient(to bottom, #740001, #000000)',
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [],
   },
   'onepiece': {
     colors: {

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -101,6 +101,8 @@ const FilterPage: React.FC = () => {
                 ? 'Demon Slayer'
                 : currentUniverse === 'league-of-legends'
                 ? 'League of Legends'
+                : currentUniverse === 'harry-potter'
+                ? 'Harry Potter'
                 : currentUniverse === 'onepiece'
                 ? 'One Piece'
                 : 'Naruto'} Tier List
@@ -110,15 +112,17 @@ const FilterPage: React.FC = () => {
           {languageSelector}
 
           <p className="mb-6 text-gray-600 dark:text-gray-300">
-            Select which {currentUniverse === 'pokemon'
-              ? 'generations'
-              : currentUniverse === 'naruto'
-              ? 'series'
-              : currentUniverse === 'league-of-legends'
-              ? 'classes'
-              : currentUniverse === 'onepiece'
-              ? 'characters'
-              : 'seasons'} you want to include in your tier list:
+              Select which {currentUniverse === 'pokemon'
+                ? 'generations'
+                : currentUniverse === 'naruto'
+                ? 'series'
+                : currentUniverse === 'league-of-legends'
+                ? 'classes'
+                : currentUniverse === 'harry-potter'
+                ? 'characters'
+                : currentUniverse === 'onepiece'
+                ? 'characters'
+                : 'seasons'} you want to include in your tier list:
           </p>
           
           {filterOptions.length > 0 && (

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -137,6 +137,8 @@ function getImageFromId(id: string) {
               ? 'Demon Slayer'
               : currentUniverse === 'league-of-legends'
               ? 'League of Legends'
+              : currentUniverse === 'harry-potter'
+              ? 'Harry Potter'
               : currentUniverse === 'onepiece'
               ? 'One Piece'
               : 'Naruto'}{' '}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -66,6 +66,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'harry-potter') {
+    try {
+      return await fetchHarryPotterCharacters();
+    } catch (error) {
+      console.error('Error fetching Harry Potter characters:', error);
+      return generateHarryPotterCharacters();
+    }
+  }
+
   if (universe === 'onepiece') {
     try {
       return await fetchOnePieceCharacters();
@@ -97,6 +106,9 @@ function getMockCharacters(universe: UniverseType, filters: string[]): Character
       break;
     case 'league-of-legends':
       characters = generateLeagueCharacters(filters);
+      break;
+    case 'harry-potter':
+      characters = generateHarryPotterCharacters();
       break;
   }
   
@@ -494,6 +506,31 @@ function generateOnePieceCharacters(): Character[] {
     name,
     image: createPlaceholderImage(name, '#2E51A2'),
     universe: 'onepiece',
+  }));
+}
+
+async function fetchHarryPotterCharacters(): Promise<Character[]> {
+  try {
+    const { data } = await axios.get('https://hp-api.onrender.com/api/characters');
+    return data.map((item: any, index: number) => ({
+      id: `harrypotter-${index}`,
+      name: item.name,
+      image: item.image || createPlaceholderImage(item.name, '#740001'),
+      universe: 'harry-potter',
+    }));
+  } catch (error) {
+    console.error('Error fetching Harry Potter characters:', error);
+    return generateHarryPotterCharacters();
+  }
+}
+
+function generateHarryPotterCharacters(): Character[] {
+  const names = ['Harry Potter', 'Hermione Granger', 'Ron Weasley', 'Albus Dumbledore', 'Severus Snape', 'Draco Malfoy'];
+  return names.map((name, index) => ({
+    id: `harrypotter-${index}`,
+    name,
+    image: createPlaceholderImage(name, '#740001'),
+    universe: 'harry-potter',
   }));
 }
 


### PR DESCRIPTION
## Summary
- add `harry-potter` to the list of universes
- configure theme and background for the new universe
- fetch characters from `hp-api`
- show the new universe name on filter and tier list pages
- add basic Harry Potter background effect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbcb0bae08325add4100d9a516363