### PR TITLE
Improve Harry Potter image coverage

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -510,6 +510,27 @@ function generateOnePieceCharacters(): Character[] {
 }
 
 async function fetchHarryPotterCharacters(): Promise<Character[]> {
+  // Try PotterDB first as it provides more images
+  try {
+    const { data } = await axios.get(
+      'https://api.potterdb.com/v1/characters?page[size]=500',
+    );
+    const characters = Array.isArray(data?.data) ? data.data : [];
+    if (characters.length > 0) {
+      return characters.map((item: any, index: number) => ({
+        id: `harrypotter-${item.id ?? index}`,
+        name: item.attributes?.name ?? `Character ${index}`,
+        image:
+          item.attributes?.image ||
+          createPlaceholderImage(item.attributes?.name ?? `Character ${index}`, '#740001'),
+        universe: 'harry-potter',
+      }));
+    }
+  } catch (error) {
+    console.error('Error fetching characters from PotterDB:', error);
+  }
+
+  // Fallback to hp-api if PotterDB fails
   try {
     const { data } = await axios.get('https://hp-api.onrender.com/api/characters');
     return data.map((item: any, index: number) => ({


### PR DESCRIPTION
## Summary
- enhance `fetchHarryPotterCharacters` by pulling images from PotterDB and falling back to the previous API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cbe503bd8832599627205a44618a4