### PR TITLE
Add placeholder fallback for HP images

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -3,6 +3,8 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Character } from '../types/types';
 import CharacterModal from './CharacterModal';
+import { createPlaceholderImage } from '../utils/image';
+import { useTheme } from '../context/ThemeContext';
 
 interface CharacterCardProps {
   character: Character;
@@ -16,32 +18,39 @@ interface CharacterCardProps {
 export const PlainCharacterCard: React.FC<CharacterCardProps> = ({
   character,
   isDragging = false,
-}) => (
-  <div
-  className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-500"
-    style={{ opacity: isDragging ? 0.8 : 1 }}
-  >
-    <img
-      src={character.thumbnail ?? character.image}
-      alt={character.name}
-      className={`w-full h-full object-cover ${
-        character.universe === 'league-of-legends' ? 'scale-[1.15]' : ''
-
-      }`}
-    />
-    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
-      <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
-        {character.name}
-      </span>
+}) => {
+  const { themeColors } = useTheme();
+  return (
+    <div
+      className="relative w-16 h-16 cursor-grab group active:cursor-grabbing rounded-md overflow-hidden shadow-sm border border-gray-200 hover:shadow-md transition-shadow dark:border-gray-500"
+      style={{ opacity: isDragging ? 0.8 : 1 }}
+    >
+      <img
+        src={character.thumbnail ?? character.image}
+        alt={character.name}
+        onError={(e) => {
+          e.currentTarget.onerror = null;
+          e.currentTarget.src = createPlaceholderImage(character.name, themeColors.primary);
+        }}
+        className={`w-full h-full object-cover ${
+          character.universe === 'league-of-legends' ? 'scale-[1.15]' : ''
+        }`}
+      />
+      <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-40 transition-all flex items-end justify-center">
+        <span className="text-white text-xs font-medium px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity truncate max-w-full">
+          {character.name}
+        </span>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const CharacterCard: React.FC<CharacterCardProps> = ({
   character,
   isDragging = false,
 }) => {
   const [modalOpen, setModalOpen] = useState(false);
+  const { themeColors } = useTheme();
   const {
     attributes,
     listeners,
@@ -69,6 +78,10 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
         <img
           src={character.thumbnail ?? character.image}
           alt={character.name}
+          onError={(e) => {
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = createPlaceholderImage(character.name, themeColors.primary);
+          }}
           className={`w-full h-full object-cover ${
             character.universe === 'league-of-legends' ? 'scale-[1.15]' : ''
           }`}

--- a/src/components/CharacterModal.tsx
+++ b/src/components/CharacterModal.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { Character } from '../types/types';
+import { createPlaceholderImage } from '../utils/image';
+import { useTheme } from '../context/ThemeContext';
 
 interface CharacterModalProps {
   character: Character;
@@ -9,6 +11,7 @@ interface CharacterModalProps {
 }
 
 const CharacterModal: React.FC<CharacterModalProps> = ({ character, onClose }) => {
+  const { themeColors } = useTheme();
   return createPortal(
     <div
       className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50"
@@ -29,6 +32,10 @@ const CharacterModal: React.FC<CharacterModalProps> = ({ character, onClose }) =
         <img
           src={character.image}
           alt={character.name}
+          onError={(e) => {
+            e.currentTarget.onerror = null;
+            e.currentTarget.src = createPlaceholderImage(character.name, themeColors.primary);
+          }}
           className={`w-full h-auto rounded-md mb-4 ${
             character.universe === 'league-of-legends' ? 'max-h-[700px]' : ''
           }`}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,23 +1,9 @@
 import axios from 'axios';
 import { Character } from '../types/types';
 import { UniverseType } from '../data/universes';
+import { createPlaceholderImage } from '../utils/image';
 
 const LOL_VERSION = '13.24.1';
-
-function createPlaceholderImage(name: string, color: string): string {
-  const initials = name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
-  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='150' height='150'>` +
-    `<rect width='100%' height='100%' fill='${color}'/>` +
-    `<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' ` +
-    `fill='#fff' font-size='60' font-family='Arial, sans-serif'>${initials}</text>` +
-    `</svg>`;
-  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
-}
 
 
 // For demo purposes, this returns mock data

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,14 @@
+export function createPlaceholderImage(name: string, color: string): string {
+  const initials = name
+    .split(' ')
+    .map(n => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+  const svg =
+    `<svg xmlns='http://www.w3.org/2000/svg' width='150' height='150'>` +
+    `<rect width='100%' height='100%' fill='${color}'/>` +
+    `<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' fill='#fff' font-size='60' font-family='Arial, sans-serif'>${initials}</text>` +
+    `</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}


### PR DESCRIPTION
## Summary
- export `createPlaceholderImage` utility
- handle broken image links with placeholders in `CharacterCard` and `CharacterModal`
- import new utility in API service

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cc0995e9483258bf4c9bcf73d5a65