### PR TITLE
Integrate PotterAPI for Harry Potter data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and provide your own PotterAPI key
+# You can obtain a key by registering at https://www.potterapi.com/
+VITE_POTTERAPI_KEY=your-api-key

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -495,12 +495,17 @@ function generateOnePieceCharacters(): Character[] {
   }));
 }
 
-// Fetch Harry Potter characters using the classic HP-API
+// Fetch Harry Potter characters using PotterAPI
+// The API key should be provided via the `VITE_POTTERAPI_KEY` env variable
 async function fetchHarryPotterCharacters(): Promise<Character[]> {
+  const apiKey = import.meta.env.VITE_POTTERAPI_KEY || '';
+  const url =
+    'https://www.potterapi.com/v1/characters' + (apiKey ? `?key=${apiKey}` : '');
+
   try {
-    const { data } = await axios.get('https://hp-api.onrender.com/api/characters');
+    const { data } = await axios.get(url);
     return data.map((item: any, index: number) => ({
-      id: `harrypotter-${index}`,
+      id: item._id ? `harrypotter-${item._id}` : `harrypotter-${index}`,
       name: item.name,
       image: item.image || createPlaceholderImage(item.name, '#740001'),
       universe: 'harry-potter',


### PR DESCRIPTION
## Summary
- use PotterAPI for retrieving Harry Potter characters
- document required `VITE_POTTERAPI_KEY` in `.env.example`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: cannot find ESLint packages)*

------
https://chatgpt.com/codex/tasks/task_e_684cc215b33883259c57bc7a91307d67