### PR TITLE
Add Plants vs Zombies category

### DIFF
--- a/src/assets/pvz-home.svg
+++ b/src/assets/pvz-home.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200">
+  <rect width="100%" height="100%" fill="#38761d"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-size="48" font-family="Arial" fill="#ffffff">PVZ</text>
+</svg>

--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -101,6 +101,25 @@ const UniverseBackground: React.FC<UniverseBackgroundProps> = ({ universe }) => 
           </>
         );
 
+      case 'pvz':
+        return (
+          <>
+            {Array.from({ length: 20 }).map((_, index) => (
+              <div
+                key={index}
+                className="absolute rounded-full bg-yellow-300 opacity-30"
+                style={{
+                  width: `${Math.random() * 10 + 5}px`,
+                  height: `${Math.random() * 10 + 5}px`,
+                  top: `${Math.random() * 100}%`,
+                  left: `${Math.random() * 100}%`,
+                  animation: `float ${Math.random() * 15 + 10}s infinite ease-in-out ${Math.random() * 5}s`,
+                }}
+              />
+            ))}
+          </>
+        );
+
       default:
         return null;
     }

--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -3,7 +3,8 @@ export type UniverseType =
   | 'naruto'
   | 'demon-slayer'
   | 'league-of-legends'
-  | 'onepiece';
+  | 'onepiece'
+  | 'pvz';
 
 export interface Universe {
   id: UniverseType;
@@ -17,6 +18,7 @@ import narutoHome from '../assets/naruto-home.png';
 import demonSlayerHome from '../assets/demon-slayer-home.png';
 import lolHome from '../assets/lol-home.svg';
 import onePieceHome from '../assets/onepiece-home.svg';
+import pvzHome from '../assets/pvz-home.svg';
 
 export const universes: Universe[] = [
   {
@@ -48,6 +50,12 @@ export const universes: Universe[] = [
     name: 'One Piece',
     description: 'Create tier lists of characters from One Piece using Jikan',
     image: onePieceHome,
+  },
+  {
+    id: 'pvz',
+    name: 'Plants vs. Zombies 2',
+    description: 'Tier lists for plants and zombies from PVZ 2',
+    image: pvzHome,
   },
 ];
 
@@ -167,5 +175,24 @@ export const universeConfig: Record<UniverseType, {
       overflow: 'hidden',
     },
     filterOptions: [],
+  },
+  'pvz': {
+    colors: {
+      primary: '#6AAA1E',
+      secondary: '#B6D53C',
+      accent: '#FFB300',
+      background: '#EAF2D6',
+      text: '#1A3B0A',
+    },
+    backgroundStyle: {
+      background: 'linear-gradient(to bottom, #3f8748, #1d3a22)',
+      backgroundSize: 'cover',
+      position: 'relative',
+      overflow: 'hidden',
+    },
+    filterOptions: [
+      { id: 'plants', name: 'Plants' },
+      { id: 'zombies', name: 'Zombies' },
+    ],
   },
 };

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -103,6 +103,8 @@ const FilterPage: React.FC = () => {
                 ? 'League of Legends'
                 : currentUniverse === 'onepiece'
                 ? 'One Piece'
+                : currentUniverse === 'pvz'
+                ? 'Plants vs. Zombies'
                 : 'Naruto'} Tier List
             </h2>
           </div>
@@ -118,6 +120,8 @@ const FilterPage: React.FC = () => {
               ? 'classes'
               : currentUniverse === 'onepiece'
               ? 'characters'
+              : currentUniverse === 'pvz'
+              ? 'types'
               : 'seasons'} you want to include in your tier list:
           </p>
           

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -139,6 +139,8 @@ function getImageFromId(id: string) {
               ? 'League of Legends'
               : currentUniverse === 'onepiece'
               ? 'One Piece'
+              : currentUniverse === 'pvz'
+              ? 'Plants vs. Zombies'
               : 'Naruto'}{' '}
             Tier List
           </h1>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -75,6 +75,15 @@ export const fetchCharacters = async (
     }
   }
 
+  if (universe === 'pvz') {
+    try {
+      return await fetchPVZCharacters(filters);
+    } catch (error) {
+      console.error('Error fetching PVZ characters:', error);
+      return generatePVZCharacters(filters);
+    }
+  }
+
 
   // For demonstration, simulate an API request with a timeout for other universes
   return new Promise((resolve) => {
@@ -495,5 +504,67 @@ function generateOnePieceCharacters(): Character[] {
     image: createPlaceholderImage(name, '#2E51A2'),
     universe: 'onepiece',
   }));
+}
+
+const PVZ_API = 'https://pvz-2-api.vercel.app/api';
+
+async function fetchPVZCharacters(filters: string[]): Promise<Character[]> {
+  const categories = filters.length > 0 ? filters : ['plants', 'zombies'];
+  const results: Character[] = [];
+
+  await Promise.all(
+    categories.map(async (category) => {
+      try {
+        const { data } = await axios.get(`${PVZ_API}/${category}`);
+        const items = Array.isArray(data) ? data : data.data || [];
+        items.forEach((item: any, index: number) => {
+          results.push({
+            id: `pvz-${category}-${index}`,
+            name: item.name || item.nom || `Unknown`,
+            image:
+              item.image ||
+              item.icon ||
+              createPlaceholderImage(item.name || 'PVZ', '#6AAA1E'),
+            universe: 'pvz',
+            type: category,
+          });
+        });
+      } catch (err) {
+        console.error(`Error fetching PVZ ${category}:`, err);
+      }
+    })
+  );
+
+  return results.length > 0 ? results : generatePVZCharacters(filters);
+}
+
+function generatePVZCharacters(filters: string[]): Character[] {
+  const cats = filters.length > 0 ? filters : ['plants', 'zombies'];
+  const characters: Character[] = [];
+  if (cats.includes('plants')) {
+    const plants = ['Peashooter', 'Sunflower', 'Wall-nut', 'Snow Pea', 'Potato Mine'];
+    plants.forEach((name, index) => {
+      characters.push({
+        id: `pvz-plant-${index}`,
+        name,
+        image: createPlaceholderImage(name, '#6AAA1E'),
+        universe: 'pvz',
+        type: 'plant',
+      });
+    });
+  }
+  if (cats.includes('zombies')) {
+    const zombies = ['Zombie', 'Conehead Zombie', 'Buckethead Zombie', 'Imp', 'Gargantuar'];
+    zombies.forEach((name, index) => {
+      characters.push({
+        id: `pvz-zombie-${index}`,
+        name,
+        image: createPlaceholderImage(name, '#6AAA1E'),
+        universe: 'pvz',
+        type: 'zombie',
+      });
+    });
+  }
+  return characters;
 }
 


### PR DESCRIPTION
## Summary
- add new PVZ category with asset
- fetch PVZ data from pvz-2-api and provide fallback
- configure theme and filters for PVZ
- display PVZ in filter and tier list pages
- show background animation for PVZ

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d9e3ba6dc8325a79efa9cc04701b6