### PR TITLE
Hide card during drag

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -49,12 +49,14 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
     setNodeRef,
     transform,
     transition,
+    isDragging: isActive,
   } = useSortable({ id: character.id });
   
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.8 : 1,
+    visibility: isActive ? 'hidden' as const : 'visible' as const,
   };
   
   return (


### PR DESCRIPTION
## Summary
- hide original card when dragging so it only shows on cursor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684db690a2e08325b6306ca0ffd63783