### PR TITLE
Remove placeholder when dragging card

### DIFF
--- a/src/components/CharacterCard.tsx
+++ b/src/components/CharacterCard.tsx
@@ -56,7 +56,7 @@ const CharacterCard: React.FC<CharacterCardProps> = ({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.8 : 1,
-    visibility: isActive ? 'hidden' as const : 'visible' as const,
+    display: isActive ? 'none' as const : undefined,
   };
   
   return (


### PR DESCRIPTION
## Summary
- hide the dragged card's source node instead of leaving an empty square

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684db7becbd083259fd1b1ba3628b62e