### PR TITLE
Fix full width tier droppable areas

### DIFF
--- a/src/components/Tier.tsx
+++ b/src/components/Tier.tsx
@@ -47,7 +47,7 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
     <div
       ref={setNodeRef}
       style={style}
-      className="flex flex-col rounded-lg bg-white shadow-md overflow-hidden dark:bg-gray-800 dark:text-white"
+      className="flex flex-col w-full rounded-lg bg-white shadow-md overflow-hidden dark:bg-gray-800 dark:text-white"
     >
       <div className="flex items-stretch">
         <div
@@ -72,7 +72,7 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
         
         <div
           ref={setDroppableRef}
-          className="flex-1 min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50 dark:bg-gray-700"
+          className="flex-1 w-full min-h-20 p-2 flex flex-wrap items-center gap-2 bg-gray-50 dark:bg-gray-700"
         >
           {isEditing ? (
             <input


### PR DESCRIPTION
## Summary
- ensure Tier component uses full width

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684db936f0408325aa8999cc0e7849cf