### PR TITLE
Add ghost image for empty tier drops

### DIFF
--- a/src/components/TierListGrid.tsx
+++ b/src/components/TierListGrid.tsx
@@ -273,6 +273,7 @@ const TierListGrid: React.FC<TierListGridProps> = ({ characters, onUnknownChange
               characters={characterMap[tier.id].map(id => characters.find(c => c.id === id)!)}
               onRemove={() => removeTier(tier.id)}
               onUpdate={(label, color) => updateTier(tier.id, label, color)}
+              activeCharacter={activeCharacter}
             />
           ))}
         </SortableContext>


### PR DESCRIPTION
## Summary
- show drag preview image when hovering over an empty tier
- supply activeCharacter to Tier so it can render preview

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dba421c2883258f313b1900c19834