### PR TITLE
Fix night mode text colors

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -73,9 +73,17 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     }
   }, [isNightMode]);
 
+  const appliedThemeColors = React.useMemo(
+    () => ({
+      ...themeColors,
+      text: isNightMode ? '#ffffff' : themeColors.text,
+    }),
+    [themeColors, isNightMode]
+  );
+
   return (
     <ThemeContext.Provider
-      value={{ currentUniverse, setCurrentUniverse, themeColors, backgroundStyle, isNightMode, toggleNightMode: () => setIsNightMode(prev => !prev) }}
+      value={{ currentUniverse, setCurrentUniverse, themeColors: appliedThemeColors, backgroundStyle, isNightMode, toggleNightMode: () => setIsNightMode(prev => !prev) }}
     >
       {children}
     </ThemeContext.Provider>


### PR DESCRIPTION
## Summary
- keep track of current theme
- apply a light text color when night mode is active so all components remain readable

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f4fced91c832593605a5875689e12