### PR TITLE
Fix League day text color

### DIFF
--- a/src/data/universes.ts
+++ b/src/data/universes.ts
@@ -143,7 +143,7 @@ export const universeConfig: Record<UniverseType, {
       secondary: '#F0E6D2', // parchment
       accent: '#C89B3C', // gold
       background: '#000',
-      text: '#E5E5E5',
+      text: '#1F2937',
     },
     backgroundStyle: {
       background: 'linear-gradient(to bottom, #0A1428, #000000)',


### PR DESCRIPTION
## Summary
- fix text colors for League of Legends in day mode so they're darker and readable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f50fcbf8c8325b136ed117a38049a