### PR TITLE
Add simple guide page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import FilterPage from './pages/FilterPage';
 import TierListPage from './pages/TierListPage';
+import GuidePage from './pages/GuidePage';
 import { ThemeProvider } from './context/ThemeContext';
 
 function App() {
@@ -13,6 +14,7 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/filter/:universe" element={<FilterPage />} />
           <Route path="/tierlist/:universe" element={<TierListPage />} />
+          <Route path="/guide" element={<GuidePage />} />
         </Routes>
       </Router>
     </ThemeProvider>

--- a/src/pages/GuidePage.tsx
+++ b/src/pages/GuidePage.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import NightModeToggle from '../components/NightModeToggle';
+
+const GuidePage: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-purple-900 to-indigo-900 text-white relative">
+      <NightModeToggle />
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        {Array.from({ length: 50 }).map((_, index) => (
+          <div
+            key={index}
+            className="absolute rounded-full bg-white"
+            style={{
+              width: `${Math.random() * 4 + 1}px`,
+              height: `${Math.random() * 4 + 1}px`,
+              top: `${Math.random() * 100}%`,
+              left: `${Math.random() * 100}%`,
+              opacity: Math.random() * 0.5 + 0.2,
+              animation: `twinkle ${Math.random() * 5 + 3}s infinite ease-in-out ${Math.random() * 5}s`,
+            }}
+          />
+        ))}
+      </div>
+      <div className="container mx-auto px-4 py-12 relative z-10">
+        <button
+          onClick={() => navigate('/')}
+          className="mb-8 bg-black bg-opacity-30 rounded-full px-4 py-2 hover:bg-opacity-40 transition-all text-white"
+        >
+          Back to Home
+        </button>
+        <h1 className="text-3xl font-bold mb-4">Guide</h1>
+        <p className="mb-4">
+          Use this application to create tier lists from your favourite universes. Select an universe,
+          apply filters and drag characters into tiers.
+        </p>
+        <p className="mb-4">
+          Note: there is a small bug with the colour display of Temtem in normal mode (not Luma).
+        </p>
+      </div>
+      <style jsx>{`
+        @keyframes twinkle {
+          0%, 100% { opacity: 0.2; }
+          50% { opacity: 0.8; }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default GuidePage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -49,6 +49,12 @@ const HomePage: React.FC = () => {
           <p className="text-lg md:text-xl max-w-2xl text-blue-100">
             Create beautiful tier lists for your favorite anime universes
           </p>
+          <button
+            onClick={() => navigate('/guide')}
+            className="mt-6 px-5 py-2 bg-indigo-600 rounded-full hover:bg-indigo-700 transition"
+          >
+            Guide
+          </button>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">


### PR DESCRIPTION
## Summary
- add a new `GuidePage` screen to describe basic features
- link to guide from homepage
- register the new page in the app router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f5e0d9c048325a9f129f1e0299084