### PR TITLE
Add language selector and translations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,18 +4,21 @@ import HomePage from './pages/HomePage';
 import FilterPage from './pages/FilterPage';
 import TierListPage from './pages/TierListPage';
 import { ThemeProvider } from './context/ThemeContext';
+import { LanguageProvider } from './context/LanguageContext';
 
 function App() {
   return (
-    <ThemeProvider>
-      <Router>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/filter/:universe" element={<FilterPage />} />
-          <Route path="/tierlist/:universe" element={<TierListPage />} />
-        </Routes>
-      </Router>
-    </ThemeProvider>
+    <LanguageProvider>
+      <ThemeProvider>
+        <Router>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/filter/:universe" element={<FilterPage />} />
+            <Route path="/tierlist/:universe" element={<TierListPage />} />
+          </Routes>
+        </Router>
+      </ThemeProvider>
+    </LanguageProvider>
   );
 }
 

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { toPng } from 'html-to-image';
 import { Download, Share2, Code } from 'lucide-react';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 interface ExportPanelProps {
   tierListRef: React.RefObject<HTMLDivElement>;
@@ -10,6 +11,7 @@ interface ExportPanelProps {
 
 const ExportPanel: React.FC<ExportPanelProps> = ({ tierListRef, tierListData }) => {
   const { themeColors } = useTheme();
+  const { t } = useLanguage();
   const [copied, setCopied] = useState(false);
   
   const exportAsImage = async () => {
@@ -63,7 +65,7 @@ const ExportPanel: React.FC<ExportPanelProps> = ({ tierListRef, tierListData }) 
   return (
     <div className="p-4 bg-white rounded-lg shadow-md dark:bg-gray-800 dark:text-white">
       <h3 className="font-medium mb-4" style={{ color: themeColors.text }}>
-        Export & Share
+        {t('exportShare')}
       </h3>
       
       <div className="flex flex-wrap gap-3">
@@ -76,7 +78,7 @@ const ExportPanel: React.FC<ExportPanelProps> = ({ tierListRef, tierListData }) 
           }}
         >
           <Download size={18} className="mr-2" />
-          Save as Image
+          {t('saveAsImage')}
         </button>
         
         <button
@@ -88,7 +90,7 @@ const ExportPanel: React.FC<ExportPanelProps> = ({ tierListRef, tierListData }) 
           }}
         >
           <Code size={18} className="mr-2" />
-          Export JSON
+          {t('exportJson')}
         </button>
         
         <button
@@ -100,7 +102,7 @@ const ExportPanel: React.FC<ExportPanelProps> = ({ tierListRef, tierListData }) 
           }}
         >
           <Share2 size={18} className="mr-2" />
-          {copied ? 'Link Copied!' : 'Copy Share Link'}
+          {copied ? t('linkCopied') : t('copyShareLink')}
         </button>
       </div>
     </div>

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+interface FlagProps {
+  code: 'us' | 'fr' | 'es';
+  size?: number;
+}
+
+const Flag: React.FC<FlagProps> = ({ code, size = 20 }) => {
+  const width = size * 1.5;
+  const height = size;
+
+  if (code === 'fr') {
+    return (
+      <svg width={width} height={height} viewBox="0 0 3 2" className="flex-shrink-0">
+        <rect width="1" height="2" fill="#0055A4" />
+        <rect x="1" width="1" height="2" fill="#ffffff" />
+        <rect x="2" width="1" height="2" fill="#EF4135" />
+      </svg>
+    );
+  }
+
+  if (code === 'es') {
+    return (
+      <svg width={width} height={height} viewBox="0 0 3 2" className="flex-shrink-0">
+        <rect width="3" height="2" fill="#AA151B" />
+        <rect y="0.5" width="3" height="1" fill="#F1BF00" />
+      </svg>
+    );
+  }
+
+  // default to US flag
+  return (
+    <svg width={width} height={height} viewBox="0 0 19 10" className="flex-shrink-0">
+      <rect width="19" height="10" fill="#B22234" />
+      <g fill="#FFFFFF">
+        <rect y="1" width="19" height="1" />
+        <rect y="3" width="19" height="1" />
+        <rect y="5" width="19" height="1" />
+        <rect y="7" width="19" height="1" />
+        <rect y="9" width="19" height="1" />
+      </g>
+      <rect width="7.6" height="5.4" fill="#3C3B6E" />
+    </svg>
+  );
+};
+
+export default Flag;

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { Upload, Plus, X } from 'lucide-react';
 import { useTheme } from '../context/ThemeContext';
 import { Character } from '../types/types';
+import { useLanguage } from '../context/LanguageContext';
 
 interface ImageUploaderProps {
   onImageUploaded: (character: Character) => void;
@@ -9,6 +10,7 @@ interface ImageUploaderProps {
 
 const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
   const { themeColors } = useTheme();
+  const { t } = useLanguage();
   const [dragActive, setDragActive] = useState(false);
   const [characterName, setCharacterName] = useState('');
   const [previewImage, setPreviewImage] = useState<string | null>(null);
@@ -68,7 +70,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
   return (
     <div className="p-4 bg-white rounded-lg shadow-md mb-6 dark:bg-gray-800 dark:text-white">
       <h3 className="font-medium mb-4" style={{ color: themeColors.text }}>
-        Add Custom Character
+        {t('addCustomCharacter')}
       </h3>
       
       {previewImage ? (
@@ -80,14 +82,14 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
             
             <div className="flex-1">
               <label className="block text-sm font-medium mb-1" style={{ color: themeColors.text }}>
-                Character Name
+                {t('characterName')}
               </label>
               <input
                 type="text"
                 value={characterName}
                 onChange={(e) => setCharacterName(e.target.value)}
                 className="w-full px-3 py-2 border rounded-md"
-                placeholder="Enter character name"
+                placeholder={t('enterCharacterName')}
                 autoFocus
               />
             </div>
@@ -101,7 +103,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
               disabled={!characterName.trim()}
             >
               <Plus size={16} className="inline mr-1" />
-              Add to Tier List
+              {t('addToTierList')}
             </button>
             
             <button
@@ -109,7 +111,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
               className="px-4 py-2 rounded-md border"
             >
               <X size={16} className="inline mr-1" />
-              Cancel
+              {t('cancel')}
             </button>
           </div>
         </div>
@@ -129,14 +131,14 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({ onImageUploaded }) => {
             style={{ color: themeColors.primary }}
           />
           <p className="mb-2 text-sm" style={{ color: themeColors.text }}>
-            Drag & drop an image, or <span
+            {t('dragDrop')} <span
               className="cursor-pointer font-medium"
               style={{ color: themeColors.primary }}
               onClick={() => fileInputRef.current?.click()}
-            >browse</span>
+            >{t('browse')}</span>
           </p>
           <p className="text-xs text-gray-500">
-            PNG, JPG or GIF up to 5MB
+            {t('fileSize')}
           </p>
           <input
             ref={fileInputRef}

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { useLanguage } from '../context/LanguageContext';
+
+const options = [
+  { code: 'en', label: 'English', flag: '🇺🇸' },
+  { code: 'fr', label: 'Français', flag: '🇫🇷' },
+  { code: 'es', label: 'Español', flag: '🇪🇸' }
+] as const;
+
+type Option = typeof options[number];
+
+const LanguageSelector: React.FC = () => {
+  const { language, setLanguage } = useLanguage();
+  const [open, setOpen] = useState(false);
+
+  const current = options.find(o => o.code === language) as Option;
+
+  const handleSelect = (code: string) => {
+    setLanguage(code as any);
+    setOpen(false);
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 text-sm z-50">
+      <button
+        className="flex items-center gap-1 bg-white dark:bg-gray-700 px-3 py-2 rounded shadow"
+        onClick={() => setOpen(o => !o)}
+      >
+        <span>{current.flag}</span>
+        <span className="font-medium uppercase">{current.code}</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 bg-white dark:bg-gray-700 rounded shadow overflow-hidden">
+          {options.map(o => (
+            <div
+              key={o.code}
+              onClick={() => handleSelect(o.code)}
+              className="cursor-pointer px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 flex items-center gap-2 whitespace-nowrap"
+            >
+              <span>{o.flag}</span>
+              <span>{o.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LanguageSelector;

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -21,21 +21,21 @@ const LanguageSelector: React.FC = () => {
   };
 
   return (
-    <div className="fixed bottom-4 right-4 text-sm z-50">
+    <div className="fixed top-4 right-4 text-sm z-50">
       <button
-        className="flex items-center gap-1 bg-white dark:bg-gray-700 px-3 py-2 rounded shadow"
+        className="flex items-center gap-1 bg-white text-black px-3 py-2 rounded shadow"
         onClick={() => setOpen(o => !o)}
       >
         <span>{current.flag}</span>
         <span className="font-medium uppercase">{current.code}</span>
       </button>
       {open && (
-        <div className="absolute right-0 mt-2 bg-white dark:bg-gray-700 rounded shadow overflow-hidden">
+        <div className="absolute right-0 mt-2 bg-white text-black rounded shadow overflow-hidden">
           {options.map(o => (
             <div
               key={o.code}
               onClick={() => handleSelect(o.code)}
-              className="cursor-pointer px-3 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 flex items-center gap-2 whitespace-nowrap"
+              className="cursor-pointer px-3 py-2 hover:bg-gray-100 flex items-center gap-2 whitespace-nowrap"
             >
               <span>{o.flag}</span>
               <span>{o.label}</span>

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { useLanguage } from '../context/LanguageContext';
+import Flag from './Flag';
 
 const options = [
-  { code: 'en', label: 'English', flag: '🇺🇸' },
-  { code: 'fr', label: 'Français', flag: '🇫🇷' },
-  { code: 'es', label: 'Español', flag: '🇪🇸' }
+  { code: 'en', label: 'English', flag: 'us' },
+  { code: 'fr', label: 'Français', flag: 'fr' },
+  { code: 'es', label: 'Español', flag: 'es' }
 ] as const;
 
 type Option = typeof options[number];
@@ -26,7 +27,7 @@ const LanguageSelector: React.FC = () => {
         className="flex items-center gap-1 bg-white text-black px-3 py-2 rounded shadow"
         onClick={() => setOpen(o => !o)}
       >
-        <span>{current.flag}</span>
+        <Flag code={current.flag} size={16} />
         <span className="font-medium uppercase">{current.code}</span>
       </button>
       {open && (
@@ -37,7 +38,7 @@ const LanguageSelector: React.FC = () => {
               onClick={() => handleSelect(o.code)}
               className="cursor-pointer px-3 py-2 hover:bg-gray-100 flex items-center gap-2 whitespace-nowrap"
             >
-              <span>{o.flag}</span>
+              <Flag code={o.flag} size={16} />
               <span>{o.label}</span>
             </div>
           ))}

--- a/src/components/Tier.tsx
+++ b/src/components/Tier.tsx
@@ -6,6 +6,7 @@ import { Trash2, Edit2 } from 'lucide-react';
 import { Character } from '../types/types';
 import CharacterCard, { PlainCharacterCard } from './CharacterCard';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 interface TierProps {
   id: string;
@@ -19,6 +20,7 @@ interface TierProps {
 
 const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onUpdate, activeCharacter }) => {
   const { themeColors } = useTheme();
+  const { t } = useLanguage();
   const [isEditing, setIsEditing] = useState(false);
   const [newLabel, setNewLabel] = useState(label);
   const [newColor, setNewColor] = useState(color);
@@ -97,7 +99,7 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
               ))}
               {characters.length === 0 && !isOver && (
                 <span className="text-gray-400 italic dark:text-gray-500 block w-full text-center">
-                  Drag characters here
+                  {t('dragCharactersHere')}
                 </span>
               )}
               {isOver && activeCharacter && characters.length === 0 && (
@@ -111,14 +113,14 @@ const Tier: React.FC<TierProps> = ({ id, label, color, characters, onRemove, onU
           <button
             onClick={handleEditSave}
           className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-200 transition-colors dark:text-gray-300 dark:hover:text-white"
-            title={isEditing ? "Save" : "Edit tier"}
+            title={isEditing ? t('save') : t('editTier')}
           >
             <Edit2 size={18} />
           </button>
           <button
             onClick={onRemove}
           className="p-2 text-gray-600 hover:text-red-600 hover:bg-gray-200 transition-colors dark:text-gray-300 dark:hover:text-red-400"
-            title="Delete tier"
+            title={t('deleteTier')}
           >
             <Trash2 size={18} />
           </button>

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,154 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
+
+type Language = 'en' | 'fr' | 'es';
+
+interface LanguageContextType {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+}
+
+const translations: Record<Language, Record<string, string>> = {
+  en: {
+    createBeautiful: 'Create beautiful tier lists for your favorite anime universes',
+    selectPokemonLanguage: 'Select Pokémon Language',
+    chooseLanguage: 'Choose language',
+    english: 'English',
+    french: 'Français',
+    spanish: 'Español',
+    selectTemtemVariant: 'Select Temtem Variant',
+    chooseVariant: 'Choose variant',
+    normal: 'Normal',
+    luma: 'Luma',
+    backToHome: 'Back to Home',
+    customizeYour: 'Customize Your',
+    tierList: 'Tier List',
+    selectWhich: 'Select which',
+    youWant: 'you want to include in your tier list:',
+    pleaseSelectLanguage: 'Please select a language first',
+    pleaseSelectVariant: 'Please select a variant first',
+    pleaseSelectOption: 'Please select at least one option to continue',
+    continue: 'Continue',
+    addCustomCharacter: 'Add Custom Character',
+    characterName: 'Character Name',
+    enterCharacterName: 'Enter character name',
+    addToTierList: 'Add to Tier List',
+    cancel: 'Cancel',
+    dragDrop: 'Drag & drop an image, or',
+    browse: 'browse',
+    fileSize: 'PNG, JPG or GIF up to 5MB',
+    exportShare: 'Export & Share',
+    saveAsImage: 'Save as Image',
+    exportJson: 'Export JSON',
+    copyShareLink: 'Copy Share Link',
+    linkCopied: 'Link Copied!',
+    backToFilters: 'Back to Filters',
+    dragCharactersHere: 'Drag characters here',
+    save: 'Save',
+    editTier: 'Edit tier',
+    deleteTier: 'Delete tier'
+  },
+  fr: {
+    createBeautiful: 'Créez de magnifiques tier lists pour vos univers d\'anime préférés',
+    selectPokemonLanguage: 'Sélectionnez la langue des Pokémon',
+    chooseLanguage: 'Choisissez la langue',
+    english: 'Anglais',
+    french: 'Français',
+    spanish: 'Espagnol',
+    selectTemtemVariant: 'Sélectionnez la variante Temtem',
+    chooseVariant: 'Choisissez la variante',
+    normal: 'Normal',
+    luma: 'Luma',
+    backToHome: 'Retour à l\'accueil',
+    customizeYour: 'Personnalisez votre',
+    tierList: 'Tier List',
+    selectWhich: 'Sélectionnez les',
+    youWant: 'que vous souhaitez inclure dans votre tier list :',
+    pleaseSelectLanguage: 'Veuillez d\'abord choisir une langue',
+    pleaseSelectVariant: 'Veuillez d\'abord choisir une variante',
+    pleaseSelectOption: 'Veuillez sélectionner au moins une option pour continuer',
+    continue: 'Continuer',
+    addCustomCharacter: 'Ajouter un personnage personnalisé',
+    characterName: 'Nom du personnage',
+    enterCharacterName: 'Entrez le nom du personnage',
+    addToTierList: 'Ajouter à la tier list',
+    cancel: 'Annuler',
+    dragDrop: 'Glissez-déposez une image ou',
+    browse: 'parcourez',
+    fileSize: 'PNG, JPG ou GIF jusqu\'à 5 Mo',
+    exportShare: 'Exporter & Partager',
+    saveAsImage: 'Enregistrer en image',
+    exportJson: 'Exporter JSON',
+    copyShareLink: 'Copier le lien de partage',
+    linkCopied: 'Lien copié !',
+    backToFilters: 'Retour aux filtres',
+    dragCharactersHere: 'Glissez les personnages ici',
+    save: 'Enregistrer',
+    editTier: 'Modifier le tier',
+    deleteTier: 'Supprimer le tier'
+  },
+  es: {
+    createBeautiful: 'Crea listas de niveles para tus universos de anime favoritos',
+    selectPokemonLanguage: 'Selecciona el idioma de Pokémon',
+    chooseLanguage: 'Elige el idioma',
+    english: 'Inglés',
+    french: 'Francés',
+    spanish: 'Español',
+    selectTemtemVariant: 'Selecciona la variante de Temtem',
+    chooseVariant: 'Elige la variante',
+    normal: 'Normal',
+    luma: 'Luma',
+    backToHome: 'Volver al inicio',
+    customizeYour: 'Personaliza tu',
+    tierList: 'Lista de niveles',
+    selectWhich: 'Selecciona las',
+    youWant: 'que quieres incluir en tu lista:',
+    pleaseSelectLanguage: 'Por favor, selecciona primero un idioma',
+    pleaseSelectVariant: 'Por favor, selecciona primero una variante',
+    pleaseSelectOption: 'Por favor, selecciona al menos una opción para continuar',
+    continue: 'Continuar',
+    addCustomCharacter: 'Agregar personaje personalizado',
+    characterName: 'Nombre del personaje',
+    enterCharacterName: 'Ingresa el nombre del personaje',
+    addToTierList: 'Agregar a la lista',
+    cancel: 'Cancelar',
+    dragDrop: 'Arrastra y suelta una imagen o',
+    browse: 'buscar',
+    fileSize: 'PNG, JPG o GIF hasta 5MB',
+    exportShare: 'Exportar y Compartir',
+    saveAsImage: 'Guardar como imagen',
+    exportJson: 'Exportar JSON',
+    copyShareLink: 'Copiar enlace para compartir',
+    linkCopied: '¡Enlace copiado!',
+    backToFilters: 'Volver a los filtros',
+    dragCharactersHere: 'Arrastra los personajes aquí',
+    save: 'Guardar',
+    editTier: 'Editar tier',
+    deleteTier: 'Eliminar tier'
+  }
+};
+
+const LanguageContext = createContext<LanguageContextType>({
+  language: 'en',
+  setLanguage: () => {},
+  t: key => translations['en'][key] || key
+});
+
+export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [language, setLanguage] = useState<Language>(() => (localStorage.getItem('language') as Language) || 'en');
+
+  useEffect(() => {
+    localStorage.setItem('language', language);
+  }, [language]);
+
+  const t = useCallback((key: string) => translations[language][key] || translations['en'][key] || key, [language]);
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);
+

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -135,10 +135,17 @@ const LanguageContext = createContext<LanguageContextType>({
 });
 
 export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [language, setLanguage] = useState<Language>(() => (localStorage.getItem('language') as Language) || 'en');
+  const [language, setLanguage] = useState<Language>(() => {
+    if (typeof window !== 'undefined' && localStorage.getItem('language')) {
+      return localStorage.getItem('language') as Language;
+    }
+    return 'en';
+  });
 
   useEffect(() => {
-    localStorage.setItem('language', language);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('language', language);
+    }
   }, [language]);
 
   const t = useCallback((key: string) => translations[language][key] || translations['en'][key] || key, [language]);

--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -5,13 +5,15 @@ import { UniverseType, universeConfig } from '../data/universes';
 import { useTheme } from '../context/ThemeContext';
 import UniverseBackground from '../components/UniverseBackground';
 import NightModeToggle from '../components/NightModeToggle';
+import { useLanguage } from '../context/LanguageContext';
 
 const FilterPage: React.FC = () => {
   const { universe } = useParams<{ universe: string }>();
   const navigate = useNavigate();
   const { currentUniverse, setCurrentUniverse, themeColors } = useTheme();
+  const { t } = useLanguage();
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
-  const [pokemonLanguage, setPokemonLanguage] = useState<'en' | 'fr' | ''>('');
+  const [pokemonLanguage, setPokemonLanguage] = useState<'en' | 'fr' | 'es' | ''>('');
   const [temtemVariant, setTemtemVariant] = useState<'normal' | 'luma' | ''>('');
   
   useEffect(() => {
@@ -32,22 +34,23 @@ const FilterPage: React.FC = () => {
   const languageSelector = currentUniverse === 'pokemon' && (
     <div className="mb-6">
       <label htmlFor="pokemon-language" className="block mb-2 font-medium">
-        Select Pokémon Language
+        {t('selectPokemonLanguage')}
       </label>
       <select
         id="pokemon-language"
         value={pokemonLanguage}
         onChange={e => {
-          setPokemonLanguage(e.target.value as 'en' | 'fr');
+          setPokemonLanguage(e.target.value as 'en' | 'fr' | 'es');
           setSelectedFilters([]);
         }}
         className="border rounded p-2 w-full bg-white text-gray-900 dark:bg-gray-700 dark:text-white dark:border-gray-600"
       >
         <option value="" disabled>
-          Choose language
+          {t('chooseLanguage')}
         </option>
-        <option value="en">English</option>
-        <option value="fr">Français</option>
+        <option value="en">{t('english')}</option>
+        <option value="fr">{t('french')}</option>
+        <option value="es">{t('spanish')}</option>
       </select>
     </div>
   );
@@ -55,7 +58,7 @@ const FilterPage: React.FC = () => {
   const variantSelector = currentUniverse === 'temtem' && (
     <div className="mb-6">
       <label htmlFor="temtem-variant" className="block mb-2 font-medium">
-        Select Temtem Variant
+        {t('selectTemtemVariant')}
       </label>
       <select
         id="temtem-variant"
@@ -64,10 +67,10 @@ const FilterPage: React.FC = () => {
         className="border rounded p-2 w-full bg-white text-gray-900 dark:bg-gray-700 dark:text-white dark:border-gray-600"
       >
         <option value="" disabled>
-          Choose variant
+          {t('chooseVariant')}
         </option>
-        <option value="normal">Normal</option>
-        <option value="luma">Luma</option>
+        <option value="normal">{t('normal')}</option>
+        <option value="luma">{t('luma')}</option>
       </select>
     </div>
   );
@@ -85,11 +88,11 @@ const FilterPage: React.FC = () => {
       navigate(`/tierlist/${currentUniverse}?filters=`);
     } else if (selectedFilters.length > 0) {
       if (currentUniverse === 'pokemon' && !pokemonLanguage) {
-        alert('Please select a language first');
+        alert(t('pleaseSelectLanguage'));
         return;
       }
       if (currentUniverse === 'temtem' && !temtemVariant) {
-        alert('Please select a variant first');
+        alert(t('pleaseSelectVariant'));
         return;
       }
       const filterParams = selectedFilters.join(',');
@@ -102,7 +105,7 @@ const FilterPage: React.FC = () => {
       );
     } else {
       // Show error or notification that at least one filter should be selected
-      alert('Please select at least one option to continue');
+      alert(t('pleaseSelectOption'));
     }
   };
 
@@ -117,14 +120,14 @@ const FilterPage: React.FC = () => {
           className="flex items-center text-white mb-8 bg-black bg-opacity-30 rounded-full px-4 py-2 hover:bg-opacity-40 transition-all"
         >
           <ChevronLeft size={20} />
-          <span>Back to Home</span>
+          <span>{t('backToHome')}</span>
         </button>
         
         <div className="max-w-2xl mx-auto bg-white bg-opacity-90 backdrop-blur-md rounded-xl shadow-xl p-8 dark:bg-gray-800 dark:bg-opacity-90 dark:text-white">
           <div className="flex items-center mb-6">
             <Filter className="mr-3" style={{ color: themeColors.primary }} />
             <h2 className="text-2xl font-bold" style={{ color: themeColors.text }}>
-              Customize Your {currentUniverse === 'pokemon'
+              {t('customizeYour')} {currentUniverse === 'pokemon'
                 ? 'Pokémon'
                 : currentUniverse === 'demon-slayer'
                 ? 'Demon Slayer'
@@ -134,7 +137,7 @@ const FilterPage: React.FC = () => {
                 ? 'One Piece'
                 : currentUniverse === 'temtem'
                 ? 'Temtem'
-                : 'Naruto'} Tier List
+                : 'Naruto'} {t('tierList')}
             </h2>
           </div>
           
@@ -142,7 +145,7 @@ const FilterPage: React.FC = () => {
           {variantSelector}
 
           <p className="mb-6 text-gray-600 dark:text-gray-300">
-            Select which {currentUniverse === 'pokemon'
+            {t('selectWhich')} {currentUniverse === 'pokemon'
               ? 'generations'
               : currentUniverse === 'naruto'
               ? 'series'
@@ -152,7 +155,7 @@ const FilterPage: React.FC = () => {
               ? 'characters'
               : currentUniverse === 'temtem'
               ? 'types'
-              : 'seasons'} you want to include in your tier list:
+              : 'seasons'} {t('youWant')}
           </p>
           
           {filterOptions.length > 0 && (
@@ -213,7 +216,7 @@ const FilterPage: React.FC = () => {
                 (currentUniverse === 'temtem' && !temtemVariant)
               }
             >
-              <span className="mr-2">Continue</span>
+              <span className="mr-2">{t('continue')}</span>
               <ArrowRight size={18} />
             </button>
           </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,10 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { Sparkles } from 'lucide-react';
 import { universes } from '../data/universes';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
+import LanguageSelector from '../components/LanguageSelector';
 
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
   const { setCurrentUniverse } = useTheme();
+  const { t } = useLanguage();
   
   // Reset universe on home page
   useEffect(() => {
@@ -47,7 +50,7 @@ const HomePage: React.FC = () => {
             <Sparkles className="text-yellow-400 ml-2" size={28} />
           </div>
           <p className="text-lg md:text-xl max-w-2xl text-blue-100">
-            Create beautiful tier lists for your favorite anime universes
+            {t('createBeautiful')}
           </p>
         </div>
 
@@ -76,7 +79,9 @@ const HomePage: React.FC = () => {
           ))}
         </div>
       </div>
-      
+
+      <LanguageSelector />
+
       <style jsx>{`
         @keyframes twinkle {
           0%, 100% { opacity: 0.2; }

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -10,6 +10,7 @@ import TierListGrid from '../components/TierListGrid';
 import ExportPanel from '../components/ExportPanel';
 import ImageUploader from '../components/ImageUploader';
 import { fetchCharacters } from '../services/api';
+import { useLanguage } from '../context/LanguageContext';
 import {
   DndContext,
   DragOverlay,
@@ -27,6 +28,7 @@ const TierListPage: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { currentUniverse, setCurrentUniverse, themeColors } = useTheme();
+  const { t } = useLanguage();
   const [characters, setCharacters] = useState<Character[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -55,7 +57,7 @@ function getImageFromId(id: string) {
 
   // Get selected filters from URL
   const filtersParam = searchParams.get('filters') ?? '';
-  const language = (searchParams.get('lang') ?? 'en') as 'en' | 'fr';
+  const language = (searchParams.get('lang') ?? 'en') as 'en' | 'fr' | 'es';
   const variant = (searchParams.get('variant') ?? 'normal') as 'normal' | 'luma';
   const filters = useMemo(
     () =>
@@ -129,7 +131,7 @@ function getImageFromId(id: string) {
           className="flex items-center text-white mb-8 bg-black bg-opacity-30 rounded-full px-4 py-2 hover:bg-opacity-40 transition-all"
         >
           <ChevronLeft size={20} />
-          <span>Back to Filters</span>
+          <span>{t('backToFilters')}</span>
         </button>
         
         <div className="mb-8">
@@ -147,8 +149,7 @@ function getImageFromId(id: string) {
               ? 'One Piece'
               : currentUniverse === 'temtem'
               ? 'Temtem'
-              : 'Naruto'}{' '}
-            Tier List
+              : 'Naruto'} {t('tierList')}
           </h1>
           <div className="flex flex-wrap gap-2">
             {filters.map(filter => (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -25,7 +25,7 @@ function createPlaceholderImage(name: string, color: string): string {
 export const fetchCharacters = async (
   universe: UniverseType,
   filters: string[],
-  language: 'en' | 'fr' = 'en',
+  language: 'en' | 'fr' | 'es' = 'en',
   variant: 'normal' | 'luma' = 'normal'
 ): Promise<Character[]> => {
   if (universe === 'pokemon') {
@@ -115,7 +115,7 @@ function getMockCharacters(universe: UniverseType, filters: string[]): Character
 
 function generatePokemonCharacters(
   filters: string[],
-  language: 'en' | 'fr' = 'en'
+  language: 'en' | 'fr' | 'es' = 'en'
 ): Character[] {
   const data: Record<string, { id: number; en: string; fr: string }[]> = {
     gen1: [
@@ -204,7 +204,7 @@ function generatePokemonCharacters(
 
 async function fetchPokemonCharacters(
   filters: string[],
-  language: 'en' | 'fr' = 'en'
+  language: 'en' | 'fr' | 'es' = 'en'
 ): Promise<Character[]> {
   const generationIds: Record<string, number> = {
     gen1: 1,


### PR DESCRIPTION
## Summary
- introduce `LanguageContext` with translations for English, French and Spanish
- add `LanguageSelector` component and show it on the home page
- update pages and components to use translated strings
- allow Spanish option in API and filtering logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f606625a88325aab7e818648ed887