### PR TITLE
Add website order button and night mode

### DIFF
--- a/src/components/OrderWebsiteButton.tsx
+++ b/src/components/OrderWebsiteButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const OrderWebsiteButton: React.FC = () => (
+  <a
+    href="https://mankindcorp.fr"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="px-4 py-2 rounded-lg font-semibold bg-gradient-to-r from-pink-500 to-yellow-500 shadow-lg hover:opacity-90"
+  >
+    Commander un site web
+  </a>
+);
+
+export default OrderWebsiteButton;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -5,6 +5,8 @@ import { universes } from '../data/universes';
 import { useTheme } from '../context/ThemeContext';
 import { useLanguage } from '../context/LanguageContext';
 import LanguageSelector from '../components/LanguageSelector';
+import NightModeToggle from '../components/NightModeToggle';
+import OrderWebsiteButton from '../components/OrderWebsiteButton';
 
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
@@ -40,14 +42,10 @@ const HomePage: React.FC = () => {
         ))}
       </div>
 
-      <a
-        href="https://mankindcorp.fr"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="fixed top-4 left-4 z-50 px-4 py-2 rounded-lg font-semibold bg-gradient-to-r from-pink-500 to-yellow-500 shadow-lg hover:opacity-90"
-      >
-        MankindCorp.fr
-      </a>
+      <div className="fixed top-4 left-4 z-50">
+        <OrderWebsiteButton />
+      </div>
+      <NightModeToggle />
       
       <div className="container mx-auto px-4 py-12">
         <div className="flex flex-col items-center justify-center text-center mb-16">

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -6,6 +6,7 @@ import { Character } from '../types/types';
 import { useTheme } from '../context/ThemeContext';
 import UniverseBackground from '../components/UniverseBackground';
 import NightModeToggle from '../components/NightModeToggle';
+import OrderWebsiteButton from '../components/OrderWebsiteButton';
 import TierListGrid from '../components/TierListGrid';
 import ExportPanel from '../components/ExportPanel';
 import ImageUploader from '../components/ImageUploader';
@@ -135,22 +136,25 @@ function getImageFromId(id: string) {
         </button>
         
         <div className="mb-8">
-          <h1
-            className="text-3xl font-bold drop-shadow-md mb-2 dark:text-white"
-            style={{ color: themeColors.text }}
-          >
-            {currentUniverse === 'pokemon'
-              ? 'Pokémon'
-              : currentUniverse === 'demon-slayer'
-              ? 'Demon Slayer'
-              : currentUniverse === 'league-of-legends'
-              ? 'League of Legends'
-              : currentUniverse === 'onepiece'
-              ? 'One Piece'
-              : currentUniverse === 'temtem'
-              ? 'Temtem'
-              : 'Naruto'} {t('tierList')}
-          </h1>
+          <div className="flex items-center justify-between">
+            <h1
+              className="text-3xl font-bold drop-shadow-md mb-2 dark:text-white"
+              style={{ color: themeColors.text }}
+            >
+              {currentUniverse === 'pokemon'
+                ? 'Pokémon'
+                : currentUniverse === 'demon-slayer'
+                ? 'Demon Slayer'
+                : currentUniverse === 'league-of-legends'
+                ? 'League of Legends'
+                : currentUniverse === 'onepiece'
+                ? 'One Piece'
+                : currentUniverse === 'temtem'
+                ? 'Temtem'
+                : 'Naruto'} {t('tierList')}
+            </h1>
+            <OrderWebsiteButton />
+          </div>
           <div className="flex flex-wrap gap-2">
             {filters.map(filter => (
               <span 


### PR DESCRIPTION
## Summary
- let users toggle day/night from the homepage too
- change the `MankindCorp.fr` button into `Commander un site web`
- show the button next to the tier list title

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852001ed0208325beab585a1b45764d