### PR TITLE
Fix filter labels and Pokemon tag names

### DIFF
--- a/src/pages/FilterPage.tsx
+++ b/src/pages/FilterPage.tsx
@@ -195,7 +195,11 @@ const FilterPage: React.FC = () => {
                       </svg>
                     )}
                   </div>
-                  <span className="font-medium">{t(option.nameKey)}</span>
+                  <span className="font-medium">
+                    {'nameKey' in option && option.nameKey
+                      ? t(option.nameKey)
+                      : option.name}
+                  </span>
                 </div>
               </div>
               ))}

--- a/src/pages/TierListPage.tsx
+++ b/src/pages/TierListPage.tsx
@@ -74,7 +74,17 @@ function getImageFromId(id: string) {
     const options = universeConfig[currentUniverse].filterOptions;
     return filters.map(f => {
       const found = options.find(o => o.id === f);
-      return found ? t(found.nameKey) : f;
+      if (!found) return f;
+      if (currentUniverse === 'pokemon') {
+        const match = /^gen(\d+)$/.exec(found.id);
+        if (match) {
+          return `gen ${match[1]}`;
+        }
+      }
+      if ('nameKey' in found && found.nameKey) {
+        return t(found.nameKey);
+      }
+      return found.name ?? f;
     });
   }, [filters, currentUniverse, t]);
   


### PR DESCRIPTION
## Summary
- show short `gen X` labels on Pokemon tier list page
- display Naruto filter names correctly when filtering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852173b8b908325bea7f6c0000f7d6f