### PR TITLE
Add globe icon to order website button

### DIFF
--- a/src/components/OrderWebsiteButton.tsx
+++ b/src/components/OrderWebsiteButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Globe } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
 
 const OrderWebsiteButton: React.FC = () => {
@@ -8,8 +9,9 @@ const OrderWebsiteButton: React.FC = () => {
       href="https://mankindcorp.fr"
       target="_blank"
       rel="noopener noreferrer"
-      className="px-5 py-2 rounded-full font-semibold text-white bg-violet-600 shadow-md border border-violet-500/50 hover:bg-violet-500 transition-colors"
+      className="flex items-center px-5 py-2 rounded-full font-semibold text-white bg-violet-600 shadow-md border border-violet-500/50 hover:bg-violet-500 transition-colors"
     >
+      <Globe size={18} className="mr-2" />
       {t('orderWebsite')}
     </a>
   );


### PR DESCRIPTION
## Summary
- add lucide-react globe icon in OrderWebsiteButton

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852a4806c208325b2c7cefcd8aa5446