### PR TITLE
Implement icon mode for large buttons

### DIFF
--- a/src/components/FeedbackButton.tsx
+++ b/src/components/FeedbackButton.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useLanguage } from '../context/LanguageContext';
+import useIconMode from '../hooks/useIconMode';
 
 const FeedbackButton: React.FC = () => {
   const { t } = useLanguage();
+  const ref = useRef<HTMLAnchorElement>(null);
+  const iconMode = useIconMode(ref);
+
   return (
     <a
+      ref={ref}
       href="https://discord.com" // replace with actual server link
       target="_blank"
       rel="noopener noreferrer"
@@ -17,7 +22,7 @@ const FeedbackButton: React.FC = () => {
         alt="Discord"
         className="w-5 h-5 mr-0 md:mr-2"
       />
-      <span className="hidden md:inline">{t('giveFeedback')}</span>
+      {!iconMode && <span className="ml-2">{t('giveFeedback')}</span>}
     </a>
   );
 };

--- a/src/components/OrderWebsiteButton.tsx
+++ b/src/components/OrderWebsiteButton.tsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Globe } from 'lucide-react';
 import { useLanguage } from '../context/LanguageContext';
+import useIconMode from '../hooks/useIconMode';
 
 const OrderWebsiteButton: React.FC = () => {
   const { t } = useLanguage();
+  const ref = useRef<HTMLAnchorElement>(null);
+  const iconMode = useIconMode(ref);
+
   return (
     <a
+      ref={ref}
       href="https://mankindcorp.fr"
       target="_blank"
       rel="noopener noreferrer"
@@ -13,7 +18,7 @@ const OrderWebsiteButton: React.FC = () => {
       title={t('orderWebsite')}
     >
       <Globe size={18} className="mr-0 md:mr-2" />
-      <span className="hidden md:inline">{t('orderWebsite')}</span>
+      {!iconMode && <span className="ml-2">{t('orderWebsite')}</span>}
     </a>
   );
 };

--- a/src/hooks/useIconMode.ts
+++ b/src/hooks/useIconMode.ts
@@ -1,0 +1,26 @@
+import { RefObject, useEffect, useState } from 'react';
+
+/**
+ * Determines whether a button should display in icon-only mode based on its width
+ * relative to the viewport. If the button takes more than 18% of the page width,
+ * icon mode is enabled.
+ * @param ref React ref of the button element
+ */
+export default function useIconMode(ref: RefObject<HTMLElement>): boolean {
+  const [iconMode, setIconMode] = useState(false);
+
+  useEffect(() => {
+    const checkSize = () => {
+      if (ref.current) {
+        const { width } = ref.current.getBoundingClientRect();
+        setIconMode(width / window.innerWidth > 0.18);
+      }
+    };
+
+    checkSize();
+    window.addEventListener('resize', checkSize);
+    return () => window.removeEventListener('resize', checkSize);
+  }, [ref]);
+
+  return iconMode;
+}


### PR DESCRIPTION
## Summary
- add a `useIconMode` hook to switch buttons to icon only when they occupy more than 18% of the viewport
- apply the hook to `FeedbackButton` and `OrderWebsiteButton`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68536a64e7988325a4ac5c3aada96400